### PR TITLE
Allow only one CR instance to pass through

### DIFF
--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v2.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v2.0.0.clusterserviceversion.yaml
@@ -128,18 +128,14 @@ spec:
           resources:
           - customresourcedefinitions
           verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
+          - '*'
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterroles
           - clusterrolebindings
+          - roles
+          - rolebindings
           verbs:
           - create
           - get
@@ -148,7 +144,7 @@ spec:
           - patch
           - update
           - delete
-        - apiGroups:
+        - apiGroups: 
           - apiregistration.k8s.io
           resources:
           - apiservices
@@ -160,7 +156,7 @@ spec:
           - patch
           - update
           - delete
-        - apiGroups:
+        - apiGroups: 
           - admissionregistration.k8s.io
           resources:
           - mutatingwebhookconfigurations
@@ -190,14 +186,9 @@ spec:
           - certificates/status
           - certificaterequests/status
           - challenges/status
-          - clusterissuers/status
-          - issuers/status
           - orders/status
-          verbs:
-          - update
-        - apiGroups:
-          - certmanager.k8s.io
-          resources:
+          - issuers/status
+          - clusterissuers/status
           - certificates/finalizers
           - challenges/finalizers
           - ingresses/finalizers
@@ -267,6 +258,15 @@ spec:
           - create
           - update
           - patch
+        - apiGroups:
+          - admission.certmanager.k8s.io
+          resources:
+          - certificates
+          - clusterissuers
+          - issuers
+          - certificaterequests
+          verbs:
+          - '*'
         serviceAccountName: ibm-cert-manager-operator
       deployments:
       - name: ibm-cert-manager-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -102,6 +102,8 @@ rules:
   resources:
   - clusterroles
   - clusterrolebindings
+  - roles
+  - rolebindings
   verbs:
   - create
   - get
@@ -168,3 +170,9 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "create", "update", "patch"]
+- apiGroups: ["admission.certmanager.k8s.io"]
+  resources: ["certificates", "clusterissuers", "issuers", "certificaterequests"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["*"]

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -88,15 +88,9 @@ rules:
 - apiGroups:
   - apiextensions.k8s.io
   resources:
-  - 'customresourcedefinitions'
+  - customresourcedefinitions
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - '*'
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -138,41 +132,102 @@ rules:
   - update
   - delete
 # In order for cert-manager clusterroles to get these permissions, the operator must have these permissions
-- apiGroups: ["certmanager.k8s.io"]
-  resources: ["certificates", "certificaterequests", "orders", "challenges", "clusterissuers", "issuers"]
-  verbs: ["*"]
-- apiGroups: ["certmanager.k8s.io"]
-  resources: ["certificates/status", "certificaterequests/status", "challenges/status", "clusterissuers/status", "issuers/status", "orders/status"]
-  verbs: ["update"]
-- apiGroups: ["certmanager.k8s.io"]
-  resources: ["certificates/finalizers", "challenges/finalizers", "ingresses/finalizers", "orders/finalizers"]
-  verbs: ["update"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "watch", "create", "update", "delete"]
-
-- apiGroups: [""]
-  resources: ["events"]
-  verbs: ["create", "patch"]
+- apiGroups:
+  - certmanager.k8s.io
+  resources:
+  - certificates
+  - certificaterequests
+  - orders
+  - challenges
+  - clusterissuers
+  - issuers
+  verbs:
+  - '*'
+- apiGroups:
+  - certmanager.k8s.io
+  resources:
+  - certificates/status
+  - certificaterequests/status
+  - challenges/status
+  - orders/status
+  - issuers/status
+  - clusterissuers/status
+  - certificates/finalizers
+  - challenges/finalizers
+  - ingresses/finalizers
+  - orders/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 # HTTP01 rules
-- apiGroups: [""]
-  resources: ["pods", "services"]
-  verbs: ["get", "list", "watch", "create", "delete"]
-- apiGroups: ["extensions"]
-  resources: ["ingresses"]
-  verbs: ["get", "list", "watch", "create", "delete", "update"]
-- apiGroups: ["apps"]
-  resources: ["deployments", "statefulsets", "daemonsets"]
-  verbs: ["*"]
-- apiGroups: ["route.openshift.io"]
-  resources: ["routes/custom-host"]
-  verbs: ["create"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["get", "create", "update", "patch"]
-- apiGroups: ["admission.certmanager.k8s.io"]
-  resources: ["certificates", "clusterissuers", "issuers", "certificaterequests"]
-  verbs: ["*"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["*"]
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  - daemonsets
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+- apiGroups:
+  - admission.certmanager.k8s.io
+  resources:
+  - certificates
+  - clusterissuers
+  - issuers
+  - certificaterequests
+  verbs:
+  - '*'

--- a/design-spec.md
+++ b/design-spec.md
@@ -2,6 +2,7 @@
 
 1. User creates `CertManager` CR
 1. Operator picks up the CR spec
+1. If the CR is not named "default", it is not allowed to pass through
 1. Operator performs reconcile loop for cert manager service
     1. Checks the instance of the CertManager CR exists
         - if it doesn't, exit

--- a/pkg/controller/certmanager/certmanager_controller.go
+++ b/pkg/controller/certmanager/certmanager_controller.go
@@ -201,7 +201,7 @@ func (r *ReconcileCertManager) Reconcile(request reconcile.Request) (reconcile.R
 	if request.Name != "default" {
 		msg := "Only one CR named default is allowed"
 		log.Info(msg, "request name", request.Name)
-		r.updateStatus(instance, "msg", corev1.EventTypeWarning, "Not Allowed")
+		r.updateStatus(instance, msg, corev1.EventTypeWarning, "Not Allowed")
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/certmanager/certmanager_controller.go
+++ b/pkg/controller/certmanager/certmanager_controller.go
@@ -198,6 +198,13 @@ func (r *ReconcileCertManager) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
+	if request.Name != "default" {
+		msg := "Only one CR named default is allowed"
+		log.Info(msg, "request name", request.Name)
+		r.updateStatus(instance, "msg", corev1.EventTypeWarning, "Not Allowed")
+		return reconcile.Result{}, nil
+	}
+
 	finalizerName := "certmanager.operators.ibm.com"
 	// Determine if the certmanager crd is going to be deleted
 	if instance.ObjectMeta.DeletionTimestamp.IsZero() {


### PR DESCRIPTION
The CR instance must be named "default"

So any CR instance not named "default" will get this status to notify them they're not allowed to be created:
````
Name:         example-certmanager
Namespace:
Labels:       <none>
Annotations:  <none>
API Version:  operator.ibm.com/v1alpha1
Kind:         CertManager
Metadata:
  Creation Timestamp:  2020-02-13T17:42:19Z
  Generation:          1
  Resource Version:    15342
  Self Link:           /apis/operator.ibm.com/v1alpha1/certmanagers/example-certmanager
  UID:                 2ee29d7a-4e88-11ea-969d-00000a1507b9
Spec:
  Enable Webhook:  true
  Image Registry:  hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64
  Pull Secret:
    Name:  pull-secret-2
Events:
  Type     Reason       Age    From                       Message
  ----     ------       ----   ----                       -------
  Warning  Not Allowed  3m40s  ibm-cert-manager-operator  Only one CR named default is allowed
````