### PR TITLE
Update CSV files & remove image pull secret

### DIFF
--- a/.osdk-scorecard.yaml
+++ b/.osdk-scorecard.yaml
@@ -1,0 +1,13 @@
+scorecard:
+  # Setting a global scorecard option
+  output: json
+  plugins:
+    # `basic` tests configured to test 2 CRs
+    - basic:
+        cr-manifest:
+          - "deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml"
+    # `olm` tests configured to test 2 CRs
+    - olm:
+        cr-manifest:
+          - "deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml"
+        csv-path: "deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v3.5.0.clusterserviceversion.yaml"

--- a/deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml
@@ -1,9 +1,7 @@
 apiVersion: operator.ibm.com/v1alpha1
 kind: CertManager
 metadata:
-  name: example-certmanager
+  name: default
 spec:
   enableWebhook: true
   imageRegistry: quay.io
-  pullSecret:
-    name: my-pull-secret

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v2.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v2.0.0.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
     containerImage: quay.io/opencloudio/ibm-cert-manager-operator:latest
     createdAt: "2020-01-14T10:16:16Z"
     support: IBM
-    certified: "false"
+    certified: "false" 
   name: ibm-cert-manager-operator.v3.5.0
   namespace: placeholder
 spec:
@@ -36,6 +36,67 @@ spec:
       kind: CertManager
       name: certmanagers.operator.ibm.com
       version: v1alpha1
+      displayName: CertManager
+      resources:
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ClusterRole
+        name: clusterroles.rbac.authorization.k8s.io
+        version: v1
+      - kind: ClusterRoleBinding
+        name: clusterrolebindings.rbac.authorization.k8s.io
+        version: v1
+      - kind: CustomResourceDefinition
+        name: customresourcedefinitions.apiextensions.k8s.io
+        version: v1beta1
+      - kind: ServiceAccount
+        name: ''
+        version: v1
+      - kind: ValidatingWebhookConfiguration
+        name: validatingwebhookconfigurations.admissionregistration.k8s.io
+        version: v1beta1
+      - kind: MutatingWebhookConfiguration
+        name: mutatingwebhookconfigurations.admissionregistration.k8s.io
+        version: v1beta1
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: APIService
+        name: apiservices.apiregistration.k8s.io
+        version: v1
+      specDescriptors:
+      - description: Enables the webhook component of cert-manager when set to true
+        displayName: EnableWebhook
+        path: enableWebhook
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: Appends the text to the image tag when it deploys cert-manager
+        displayName: ImagePostFix
+        path: imagePostFix
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: Sets the image registry to this when deploying cert-manager
+        displayName: ImageRegistry
+        path: imageRegistry
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: Uses this pull secret name to pull the cert-manager images when specified
+        displayName: Pull Secret Name
+        path: pullSecret.name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: Copies the pull secret name from this namespace to pull the cert-manager images when specified
+        displayName: Pull Secret Namespace
+        path: pullSecret.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      statusDescriptors:
+      - description: The status of deploying cert-manager
+        displayName: Status
+        path: CertManagerStatus
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
   description: Operator for managing deployment of cert-manager service.
   displayName: Ibm Cert Manager Operator
   install:

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v3.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v3.5.0.clusterserviceversion.yaml
@@ -8,14 +8,11 @@ metadata:
           "apiVersion": "operator.ibm.com/v1alpha1",
           "kind": "CertManager",
           "metadata": {
-            "name": "example-certmanager"
+            "name": "default"
           },
           "spec": {
             "enableWebhook": true,
             "imageRegistry": "quay.io",
-            "pullSecret": {
-              "name": "my-pull-secret"
-            }
           }
         }
       ]
@@ -362,8 +359,6 @@ spec:
                 imagePullPolicy: Always
                 name: ibm-cert-manager-operator
                 resources: {}
-              imagePullSecrets:
-              - name: pull-secret-1
               serviceAccountName: ibm-cert-manager-operator
     strategy: deployment
   installModes:

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v3.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v3.5.0.clusterserviceversion.yaml
@@ -358,7 +358,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: ibm-cert-manager-operator
-                image: quay.io./opencloudio/ibm-cert-manager-operator:latest
+                image: quay.io/opencloudio/ibm-cert-manager-operator:latest
                 imagePullPolicy: Always
                 name: ibm-cert-manager-operator
                 resources: {}

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v3.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v3.5.0.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
     containerImage: quay.io/opencloudio/ibm-cert-manager-operator:latest
     createdAt: "2020-01-14T10:16:16Z"
     support: IBM
-    certified: "false" 
+    certified: "false"
   name: ibm-cert-manager-operator.v3.5.0
   namespace: placeholder
 spec:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -12,8 +12,6 @@ spec:
       labels:
         name: ibm-cert-manager-operator
     spec:
-      imagePullSecrets:
-      - name: pull-secret-1
       serviceAccountName: ibm-cert-manager-operator
       containers:
         - name: ibm-cert-manager-operator

--- a/pkg/controller/certmanager/prereqs.go
+++ b/pkg/controller/certmanager/prereqs.go
@@ -18,14 +18,12 @@ package certmanager
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	operatorv1alpha1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/operator/v1alpha1"
 	res "github.com/ibm/ibm-cert-manager-operator/pkg/resources"
 
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionclientsetv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,80 +37,9 @@ import (
 
 // Check all RBAC is ready for cert-manager
 func checkRbac(instance *operatorv1alpha1.CertManager, scheme *runtime.Scheme, client client.Client) error {
-	if imagePullSecretError := imagePullSecret(scheme, client, instance); imagePullSecretError != nil {
-		return imagePullSecretError
-	}
 	if rolesError := roles(instance, scheme, client); rolesError != nil {
 		return rolesError
 	}
-	return nil
-}
-
-// Check that the image pull secret exists in the deploy namespace (cert-manager)
-// returns nil if it does, an error otherwise
-// We never create the image pull secret since it contains credentials. We only copy it or use the one provided.
-func imagePullSecret(scheme *runtime.Scheme, client client.Client, instance *operatorv1alpha1.CertManager) error {
-	pullSecret := &corev1.Secret{}
-	copyPullSecret := &corev1.Secret{}
-
-	name := res.ImagePullSecret
-	namespace := res.DeployNamespace
-
-	pullSecretExists := true
-	copyPullSecretExists := false
-
-	if instance.Spec.PullSecret.Name != "" {
-		name = instance.Spec.PullSecret.Name
-	}
-
-	err := client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: namespace}, pullSecret)
-	if err != nil && apiErrors.IsNotFound(err) { // Pull secret does not already exist in namespace
-		pullSecretExists = false
-	}
-
-	// Get secret from the namespace in the spec and copy it over to the cert-manager namespace
-	if instance.Spec.PullSecret.Namespace != "" {
-		err := client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: instance.Spec.PullSecret.Namespace}, copyPullSecret)
-		if err != nil && apiErrors.IsNotFound(err) {
-			log.V(2).Info("Image pull secret not found in specified namespace",
-				"pull secret name", name, "pull secret namespace", instance.Spec.PullSecret.Namespace)
-		} else {
-			copyPullSecretExists = true
-		}
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Data:       copyPullSecret.Data,
-		StringData: copyPullSecret.StringData,
-		Type:       copyPullSecret.Type,
-	}
-	if err := controllerutil.SetControllerReference(instance, secret, scheme); err != nil {
-		log.Error(err, "Error setting controller reference on image pull secret")
-	}
-
-	if pullSecretExists && copyPullSecretExists { // Perform update to existing pull secret
-		if err = client.Update(context.Background(), secret); err != nil {
-			return err
-		}
-		log.V(2).Info("Updated image pull secret")
-	} else if copyPullSecretExists && !pullSecretExists { // Copy it over using create
-		if err = client.Create(context.Background(), secret); err != nil {
-			return err
-		}
-		log.V(2).Info("Created image pull secret")
-	} else if !copyPullSecretExists && !pullSecretExists { // Secret not found at all, throw an error
-		errorMsg := apiErrors.NewNotFound(corev1.Resource("secrets"),
-			fmt.Sprintf("The image pull secret %s does not exist in the deploy namespace %s and there was no copy pull secret found in the %s namespace",
-				name, namespace, instance.Spec.PullSecret.Namespace))
-		log.Error(errorMsg, "Neither pull secret exist")
-		return errorMsg
-	}
-	// Pull secret exists and there's no copy pull secret
-	log.V(2).Info("Pull secret exists")
 	return nil
 }
 

--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -152,9 +152,6 @@ const cainjectorImage = imageRegistry + "/" + CainjectorImageName + ":" + Contro
 const webhookImage = imageRegistry + "/" + WebhookImageName + ":" + WebhookImageVersion
 const configmapWatcherImage = imageRegistry + "/" + ConfigmapWatcherImageName + ":" + ConfigmapWatcherVersion
 
-// ImagePullSecret is the default image pull secret name
-const ImagePullSecret = "image-pull-secret"
-
 // ServiceAccount is the name of the default service account to be used by cert-manager services
 const ServiceAccount = "default"
 

--- a/pkg/resources/pods.go
+++ b/pkg/resources/pods.go
@@ -27,9 +27,6 @@ var podSecurity = &corev1.PodSecurityContext{
 }
 
 var certManagerControllerPod = corev1.PodSpec{
-	ImagePullSecrets: []corev1.LocalObjectReference{{
-		Name: ImagePullSecret,
-	}},
 	ServiceAccountName: ServiceAccount,
 	SecurityContext:    podSecurity,
 	Containers: []corev1.Container{
@@ -38,9 +35,6 @@ var certManagerControllerPod = corev1.PodSpec{
 }
 
 var certManagerWebhookPod = corev1.PodSpec{
-	ImagePullSecrets: []corev1.LocalObjectReference{{
-		Name: ImagePullSecret,
-	}},
 	HostNetwork:        TrueVar,
 	ServiceAccountName: ServiceAccount,
 	SecurityContext:    podSecurity,
@@ -60,9 +54,6 @@ var certManagerWebhookPod = corev1.PodSpec{
 }
 
 var certManagerCainjectorPod = corev1.PodSpec{
-	ImagePullSecrets: []corev1.LocalObjectReference{{
-		Name: ImagePullSecret,
-	}},
 	ServiceAccountName: ServiceAccount,
 	SecurityContext:    podSecurity,
 	Containers: []corev1.Container{
@@ -71,9 +62,6 @@ var certManagerCainjectorPod = corev1.PodSpec{
 }
 
 var configmapWatcherPod = corev1.PodSpec{
-	ImagePullSecrets: []corev1.LocalObjectReference{{
-		Name: ImagePullSecret,
-	}},
 	ServiceAccountName: ServiceAccount,
 	SecurityContext:    podSecurity,
 	Containers: []corev1.Container{


### PR DESCRIPTION
The CSV files needed to be update for both the issue below and with the missing information needed for pushing to quay.io/application.

We're removing the image pull secret since the images for both the operator and the operand will be in a public repository or (in the event of an offline install) will be in the OCP registry and should be public.

https://github.com/IBM/ibm-cert-manager-operator/issues/9
