### PR TITLE
Fixed the namespace of the service account in the clusterrolebinding

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -22,6 +22,7 @@ rules:
   - configmaps
   - secrets
   - serviceaccounts
+  - namespaces
   verbs:
   - create
   - delete

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: ibm-cert-manager-operator
-  namespace: cert-manager
+  namespace: ibm-cert-manager-operator
 roleRef:
   kind: ClusterRole
   name: ibm-cert-manager-operator

--- a/pkg/controller/certmanager/prereqs.go
+++ b/pkg/controller/certmanager/prereqs.go
@@ -95,6 +95,7 @@ func createClusterRoleBinding(instance *operatorv1alpha1.CertManager, scheme *ru
 
 func createServiceAccount(instance *operatorv1alpha1.CertManager, scheme *runtime.Scheme, client client.Client) error {
 	log.V(2).Info("Creating service account")
+	res.DefaultServiceAccount.ResourceVersion = ""
 	err := client.Create(context.Background(), res.DefaultServiceAccount)
 	if err := controllerutil.SetControllerReference(instance, res.DefaultServiceAccount, scheme); err != nil {
 		log.Error(err, "Error setting controller reference on service account")
@@ -117,6 +118,8 @@ func checkNamespace(client typedCorev1.NamespaceInterface) error {
 		if _, err = client.Create(res.NamespaceDef); err != nil {
 			return err
 		}
+	} else if err != nil {
+		return err
 	}
 	log.V(2).Info("cert-manager namespace exists")
 	return nil

--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -123,10 +123,10 @@ const ConfigmapWatcherName = "configmap-watcher"
 const imageRegistry = "quay.io"
 
 // ControllerImageVersion is the image version used for the cert-manager-controller
-const ControllerImageVersion = "0.10.0"
+const ControllerImageVersion = "0.10.3"
 
 // WebhookImageVersion is the image version used for the cert-manager-webhook
-const WebhookImageVersion = "0.10.1"
+const WebhookImageVersion = "0.10.3"
 
 // ConfigmapWatcherVersion is the image version used for the configmap-watcher
 const ConfigmapWatcherVersion = "3.3.0"


### PR DESCRIPTION
Since we deploy in the `ibm-cert-manager-operator` namespace according to what we wrote in the [onboarding to meta-operator PR](https://github.com/IBM/meta-operator/pull/69/files), we need to fix the namespace referenced in the clusterrolebinding for the service account which will now be in the `ibm-cert-manager-operator` namespace. 

Also adding additional permission to namespaces in our role and returning any errors when we check for namespaces that are not a NotFound error.
