### PR TITLE
Update deployment logic

### DIFF
--- a/pkg/controller/certmanager/deploys.go
+++ b/pkg/controller/certmanager/deploys.go
@@ -160,7 +160,7 @@ func deployFinder(client kubernetes.Interface, labels, name string) []appsv1.Dep
 	if err != nil {
 		log.Error(err, "Error retrieving deployments by label")
 	} else {
-		for _, deploy := range deployList.Items { // These will need to be removed
+		for _, deploy := range deployList.Items {
 			log.V(3).Info("Found deployment by labels",
 				"name", deploy.ObjectMeta.Name, "namespace",
 				deploy.ObjectMeta.Namespace, "labels", fmt.Sprintf("%v", deploy.ObjectMeta.Labels))
@@ -179,7 +179,7 @@ func deployFinder(client kubernetes.Interface, labels, name string) []appsv1.Dep
 	if err != nil {
 		log.Error(err, "Error retrieving deployments")
 	} else {
-		for _, deploy := range deployList.Items { // These will need to be removed
+		for _, deploy := range deployList.Items {
 			if strings.Contains(deploy.Spec.Template.Spec.Containers[0].Image, name) { // Deploys the same image
 				log.V(3).Info("Found deployment by image name",
 					"name", deploy.ObjectMeta.Name, "namespace", deploy.ObjectMeta.Namespace,

--- a/pkg/controller/certmanager/deploys.go
+++ b/pkg/controller/certmanager/deploys.go
@@ -63,8 +63,10 @@ func deployLogic(instance *operatorv1alpha1.CertManager, client client.Client, k
 	log.V(4).Info("The similar deploys", "all of them", fmt.Sprintf("%v", similarDeploys))
 
 	for _, deploy := range similarDeploys {
-		if !(deploy.Name == name && deploy.Namespace == res.DeployNamespace) { // If there's more than one, and it's not the correct one, return an error with a warning
-			errMsg := fmt.Sprintf("The service %s is already deployed as %s/%s. Please remove it if you want this version of %s to be deployed.", name, deploy.Namespace, deploy.Name, name)
+		if !(deploy.Name == name && deploy.Namespace == res.DeployNamespace) {
+			// If there's more than one, and it's not the correct one, return an error with a warning
+			errMsg := fmt.Sprintf("The service %s is already deployed as %s/%s. Please remove it if you want this version of %s to be deployed.",
+				name, deploy.Namespace, deploy.Name, name)
 			log.V(4).Info(errMsg)
 			err := errors.New(errMsg)
 			return err

--- a/pkg/controller/certmanager/prereqs.go
+++ b/pkg/controller/certmanager/prereqs.go
@@ -126,7 +126,7 @@ func checkNamespace(client typedCorev1.NamespaceInterface) error {
 // Takes action to create them if they do not exist
 func checkCrds(instance *operatorv1alpha1.CertManager, scheme *runtime.Scheme, client apiextensionclientsetv1beta1.CustomResourceDefinitionInterface, name, namespace string) error {
 	var allErrors []string
-	listOptions := metav1.ListOptions{LabelSelector: res.ControllerLabels}
+	listOptions := metav1.ListOptions{}
 	customResourcesList, err := client.List(listOptions)
 	if err != nil {
 		return err
@@ -134,7 +134,9 @@ func checkCrds(instance *operatorv1alpha1.CertManager, scheme *runtime.Scheme, c
 
 	existingResources := make(map[string]bool)
 	for _, item := range customResourcesList.Items {
-		existingResources[item.Name] = false
+		if strings.Contains(item.Name, res.GroupVersion) {
+			existingResources[item.Name] = false
+		}
 	}
 
 	// Check that the CRDs we need match the ones we got from the cluster


### PR DESCRIPTION
Previously if the operator found other deployments of cert-manager (without the same name/namespace) it would deterministically delete it. Now, the logic is to show a warning that one already exists and suggests to remove it before we are able to deploy our own. 