### PR TITLE
Added ownership to the namespace and removed runAsUser.

### DIFF
--- a/pkg/controller/certmanager/certmanager_controller.go
+++ b/pkg/controller/certmanager/certmanager_controller.go
@@ -254,7 +254,7 @@ func (r *ReconcileCertManager) PreReqs(instance *operatorv1alpha1.CertManager) e
 		log.V(2).Info("Checking CRDs failed")
 		return err
 	}
-	if err := checkNamespace(r.kubeclient.CoreV1().Namespaces()); err != nil {
+	if err := checkNamespace(instance, r.scheme, r.kubeclient.CoreV1().Namespaces()); err != nil {
 		log.V(2).Info("Checking namespace failed")
 		return err
 	}

--- a/pkg/controller/certmanager/prereqs.go
+++ b/pkg/controller/certmanager/prereqs.go
@@ -110,10 +110,13 @@ func createServiceAccount(instance *operatorv1alpha1.CertManager, scheme *runtim
 }
 
 // Checks to ensure the namespace we're deploying the service in exists
-func checkNamespace(client typedCorev1.NamespaceInterface) error {
+func checkNamespace(instance *operatorv1alpha1.CertManager, scheme *runtime.Scheme, client typedCorev1.NamespaceInterface) error {
 	getOpt := metav1.GetOptions{}
 
 	if _, err := client.Get(res.DeployNamespace, getOpt); err != nil && apiErrors.IsNotFound(err) {
+		if err = controllerutil.SetControllerReference(instance, res.NamespaceDef, scheme); err != nil {
+			log.Error(err, "Error setting controller reference on namespace")
+		}
 		log.V(1).Info("cert-manager namespace does not exist, creating it", "error", err)
 		if _, err = client.Create(res.NamespaceDef); err != nil {
 			return err

--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -160,7 +160,6 @@ const ClusterRoleName = "cert-manager"
 
 // SecurityContext values
 var runAsNonRoot = true
-var runAsUser int64 = 1000550001
 
 // Liveness/Readiness Probe
 var initialDelaySecondsLiveness int32 = 30

--- a/pkg/resources/containers.go
+++ b/pkg/resources/containers.go
@@ -23,7 +23,6 @@ import (
 
 var containerSecurityGeneral = &corev1.SecurityContext{
 	RunAsNonRoot:             &runAsNonRoot,
-	RunAsUser:                &runAsUser,
 	AllowPrivilegeEscalation: &FalseVar,
 	ReadOnlyRootFilesystem:   &TrueVar,
 	Privileged:               &FalseVar,
@@ -36,7 +35,6 @@ var containerSecurityGeneral = &corev1.SecurityContext{
 
 var containerSecurityWebhook = &corev1.SecurityContext{
 	RunAsNonRoot:             &runAsNonRoot,
-	RunAsUser:                &runAsUser,
 	AllowPrivilegeEscalation: &FalseVar,
 	ReadOnlyRootFilesystem:   &FalseVar,
 	Privileged:               &FalseVar,

--- a/pkg/resources/pods.go
+++ b/pkg/resources/pods.go
@@ -22,7 +22,6 @@ import (
 
 var podSecurity = &corev1.PodSecurityContext{
 	RunAsNonRoot: &runAsNonRoot,
-	RunAsUser:    &runAsUser,
 }
 
 var certManagerControllerPod = corev1.PodSpec{


### PR DESCRIPTION
Owning the cert-manager namespace so it's removed when the CR of CertManager is removed.
Also removed runAsUser since the range kept changing 
````
  Warning  FailedCreate  7s (x13 over 28s)  replicaset-controller  Error creating: pods "cert-manager-controller-bbfb69bb5-" is forbidden: unable to validate against any security context constraint: [spec.containers[0].securityContext.securityContext.runAsUser: Invalid value: 1000550001: must be in the ranges: [1000570000, 1000579999] spec.containers[0].securityContext.securityContext.runAsUser: Invalid value: 1000550001: must be in the ranges: [1000570000, 1000579999]]
````