### PR TITLE
Deploy all cert-manager resources in the same namespace that the operator is deployed in

### DIFF
--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -40,7 +40,6 @@ linters:
     - govet
     - ineffassign
     - interfacer
-    - lll
     - misspell
     - staticcheck
     - structcheck

--- a/go.sum
+++ b/go.sum
@@ -479,6 +479,7 @@ github.com/operator-framework/operator-lifecycle-manager v0.0.0-20191115003340-1
 github.com/operator-framework/operator-registry v1.5.1/go.mod h1:agrQlkWOo1q8U1SAaLSS2WQ+Z9vswNT2M2HFib9iuLY=
 github.com/operator-framework/operator-sdk v0.13.0 h1:AWiKOl6ZeAyQgbGVoD8fNd+eCbFuRWgr4hciaaOEBmE=
 github.com/operator-framework/operator-sdk v0.13.0/go.mod h1:XRnicDD4uZCNbJbMXc0B7eyw7hjO4Xzol7FAkWHa1Nc=
+github.com/operator-framework/operator-sdk v0.15.2 h1:VlxI0J+HLmMKs5k53drQ/B1AXhyNj0OaD2BbREt8Hnk=
 github.com/otiai10/copy v1.0.1/go.mod h1:8bMCJrAqOtN/d9oyh5HR7HhLQMvcGMpGdwRDYsfOCHc=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776/go.mod h1:3HNVkVOU7vZeFXocWuvtcS0XSFLcf2XUSDHkq9t1jU4=

--- a/pkg/controller/certmanager/certmanager_controller.go
+++ b/pkg/controller/certmanager/certmanager_controller.go
@@ -22,6 +22,7 @@ import (
 	operatorv1alpha1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/operator/v1alpha1"
 	res "github.com/ibm/ibm-cert-manager-operator/pkg/resources"
 
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	admRegv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -59,12 +60,16 @@ func Add(mgr manager.Manager) error {
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	apiextclient, _ := apiextensionclientset.NewForConfig(mgr.GetConfig())
 	kubeclient, _ := kubernetes.NewForConfig(mgr.GetConfig())
+	ns, _ := k8sutil.GetWatchNamespace()
+
 	return &ReconcileCertManager{
 		client:       mgr.GetClient(),
 		kubeclient:   kubeclient,
 		apiextclient: apiextclient,
 		scheme:       mgr.GetScheme(),
-		recorder:     mgr.GetEventRecorderFor("ibm-cert-manager-operator")}
+		recorder:     mgr.GetEventRecorderFor("ibm-cert-manager-operator"),
+		ns:           ns,
+	}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -173,6 +178,7 @@ type ReconcileCertManager struct {
 	apiextclient apiextensionclientset.Interface
 	scheme       *runtime.Scheme
 	recorder     record.EventRecorder
+	ns           string
 }
 
 // Reconcile reads that state of the cluster for a CertManager object and makes changes based on the state read
@@ -254,11 +260,7 @@ func (r *ReconcileCertManager) PreReqs(instance *operatorv1alpha1.CertManager) e
 		log.V(2).Info("Checking CRDs failed")
 		return err
 	}
-	/* 	if err := checkNamespace(instance, r.scheme, r.kubeclient.CoreV1().Namespaces()); err != nil {
-		log.V(2).Info("Checking namespace failed")
-		return err
-	} */
-	if err := checkRbac(instance, r.scheme, r.client); err != nil {
+	if err := checkRbac(instance, r.scheme, r.client, r.ns); err != nil {
 		log.V(2).Info("Checking RBAC failed")
 		return err
 	}
@@ -266,24 +268,24 @@ func (r *ReconcileCertManager) PreReqs(instance *operatorv1alpha1.CertManager) e
 }
 
 func (r *ReconcileCertManager) deployments(instance *operatorv1alpha1.CertManager) error {
-	if err := certManagerDeploy(instance, r.client, r.kubeclient, r.scheme); err != nil {
+	if err := certManagerDeploy(instance, r.client, r.kubeclient, r.scheme, r.ns); err != nil {
 		return err
 	}
 
-	if err := configmapWatcherDeploy(instance, r.client, r.kubeclient, r.scheme); err != nil {
+	if err := configmapWatcherDeploy(instance, r.client, r.kubeclient, r.scheme, r.ns); err != nil {
 		return err
 	}
 
 	if instance.Spec.Webhook {
 		// Check webhook prerequisites
-		if err := webhookPrereqs(instance, r.scheme, r.client); err != nil {
+		if err := webhookPrereqs(instance, r.scheme, r.client, r.ns); err != nil {
 			return err
 		}
 		// Deploy webhook and cainjector
-		if err := cainjectorDeploy(instance, r.client, r.kubeclient, r.scheme); err != nil {
+		if err := cainjectorDeploy(instance, r.client, r.kubeclient, r.scheme, r.ns); err != nil {
 			return err
 		}
-		if err := webhookDeploy(instance, r.client, r.kubeclient, r.scheme); err != nil {
+		if err := webhookDeploy(instance, r.client, r.kubeclient, r.scheme, r.ns); err != nil {
 			return err
 		}
 	} else {
@@ -299,7 +301,7 @@ func (r *ReconcileCertManager) deployments(instance *operatorv1alpha1.CertManage
 			return cainjector
 		}
 		// Remove webhook prerequisites
-		if err := removeWebhookPrereqs(r.client); err != nil {
+		if err := removeWebhookPrereqs(r.client, r.ns); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/certmanager/certmanager_controller.go
+++ b/pkg/controller/certmanager/certmanager_controller.go
@@ -254,10 +254,10 @@ func (r *ReconcileCertManager) PreReqs(instance *operatorv1alpha1.CertManager) e
 		log.V(2).Info("Checking CRDs failed")
 		return err
 	}
-	if err := checkNamespace(instance, r.scheme, r.kubeclient.CoreV1().Namespaces()); err != nil {
+	/* 	if err := checkNamespace(instance, r.scheme, r.kubeclient.CoreV1().Namespaces()); err != nil {
 		log.V(2).Info("Checking namespace failed")
 		return err
-	}
+	} */
 	if err := checkRbac(instance, r.scheme, r.client); err != nil {
 		log.V(2).Info("Checking RBAC failed")
 		return err

--- a/pkg/controller/certmanager/deploys.go
+++ b/pkg/controller/certmanager/deploys.go
@@ -36,25 +36,25 @@ import (
 )
 
 // Returns true if no errors in deploy logic
-func certManagerDeploy(instance *operatorv1alpha1.CertManager, client client.Client, kubeclient kubernetes.Interface, scheme *runtime.Scheme) error {
-	return deployLogic(instance, client, kubeclient, scheme, res.ControllerDeployment, res.CertManagerControllerName, res.ControllerImageName, res.ControllerLabels)
+func certManagerDeploy(instance *operatorv1alpha1.CertManager, client client.Client, kubeclient kubernetes.Interface, scheme *runtime.Scheme, ns string) error {
+	return deployLogic(instance, client, kubeclient, scheme, res.ControllerDeployment, res.CertManagerControllerName, res.ControllerImageName, res.ControllerLabels, ns)
 }
 
-func cainjectorDeploy(instance *operatorv1alpha1.CertManager, client client.Client, kubeclient kubernetes.Interface, scheme *runtime.Scheme) error {
-	return deployLogic(instance, client, kubeclient, scheme, res.CainjectorDeployment, res.CertManagerCainjectorName, res.CainjectorImageName, res.CainjectorLabels)
+func cainjectorDeploy(instance *operatorv1alpha1.CertManager, client client.Client, kubeclient kubernetes.Interface, scheme *runtime.Scheme, ns string) error {
+	return deployLogic(instance, client, kubeclient, scheme, res.CainjectorDeployment, res.CertManagerCainjectorName, res.CainjectorImageName, res.CainjectorLabels, ns)
 }
 
-func webhookDeploy(instance *operatorv1alpha1.CertManager, client client.Client, kubeclient kubernetes.Interface, scheme *runtime.Scheme) error {
-	return deployLogic(instance, client, kubeclient, scheme, res.WebhookDeployment, res.CertManagerWebhookName, res.WebhookImageName, res.WebhookLabels)
+func webhookDeploy(instance *operatorv1alpha1.CertManager, client client.Client, kubeclient kubernetes.Interface, scheme *runtime.Scheme, ns string) error {
+	return deployLogic(instance, client, kubeclient, scheme, res.WebhookDeployment, res.CertManagerWebhookName, res.WebhookImageName, res.WebhookLabels, ns)
 }
 
-func configmapWatcherDeploy(instance *operatorv1alpha1.CertManager, client client.Client, kubeclient kubernetes.Interface, scheme *runtime.Scheme) error {
-	return deployLogic(instance, client, kubeclient, scheme, res.ConfigmapWatcherDeployment, res.ConfigmapWatcherName, res.ConfigmapWatcherImageName, res.ConfigmapWatcherLabels)
+func configmapWatcherDeploy(instance *operatorv1alpha1.CertManager, client client.Client, kubeclient kubernetes.Interface, scheme *runtime.Scheme, ns string) error {
+	return deployLogic(instance, client, kubeclient, scheme, res.ConfigmapWatcherDeployment, res.ConfigmapWatcherName, res.ConfigmapWatcherImageName, res.ConfigmapWatcherLabels, ns)
 }
 
-func deployLogic(instance *operatorv1alpha1.CertManager, client client.Client, kubeclient kubernetes.Interface, scheme *runtime.Scheme, deployTemplate *appsv1.Deployment, name, imageName, labels string) error {
+func deployLogic(instance *operatorv1alpha1.CertManager, client client.Client, kubeclient kubernetes.Interface, scheme *runtime.Scheme, deployTemplate *appsv1.Deployment, name, imageName, labels, ns string) error {
 	similarDeploys := deployFinder(kubeclient, labels, imageName)
-	deployment := setupDeploy(instance, deployTemplate)
+	deployment := setupDeploy(instance, deployTemplate, ns)
 	var existingDeploy appsv1.Deployment
 	create := true
 
@@ -63,7 +63,7 @@ func deployLogic(instance *operatorv1alpha1.CertManager, client client.Client, k
 	log.V(4).Info("The similar deploys", "all of them", fmt.Sprintf("%v", similarDeploys))
 
 	for _, deploy := range similarDeploys {
-		if !(deploy.Name == name && deploy.Namespace == res.DeployNamespace) {
+		if !(deploy.Name == name && deploy.Namespace == ns) {
 			// If there's more than one, and it's not the correct one, return an error with a warning
 			errMsg := fmt.Sprintf("The service %s is already deployed as %s/%s. Please remove it if you want this version of %s to be deployed.",
 				name, deploy.Namespace, deploy.Name, name)
@@ -103,7 +103,7 @@ func deployLogic(instance *operatorv1alpha1.CertManager, client client.Client, k
 // Args:deploy
 //     instance - The CR instance of CertManager
 //     deploy - The base deployment object - template contains most of the defaults/constants for the deployment
-func setupDeploy(instance *operatorv1alpha1.CertManager, deploy *appsv1.Deployment) appsv1.Deployment {
+func setupDeploy(instance *operatorv1alpha1.CertManager, deploy *appsv1.Deployment, ns string) appsv1.Deployment {
 	// First copy the deploy template into a deployment object
 
 	returningDeploy := *deploy
@@ -120,9 +120,12 @@ func setupDeploy(instance *operatorv1alpha1.CertManager, deploy *appsv1.Deployme
 		if instance.Spec.ResourceNS != "" {
 			resourceNS = "--cluster-resource-namespace=" + instance.Spec.ResourceNS
 		}
+		var leaderElect = "--leader-election-namespace=" + ns
+		var webhookNS = "--webhook-namespace=" + ns
+		var webhookDNS = "--webhook-dns-names=cert-manager-webhook,cert-manager-webhook." + ns + ",cert-manager-webhook." + ns + ".svc"
 		var args = make([]string, len(res.DefaultArgs))
 		copy(args, res.DefaultArgs)
-		args = append(args, acmesolver, resourceNS)
+		args = append(args, acmesolver, resourceNS, leaderElect, webhookNS, webhookDNS)
 		returningDeploy.Spec.Template.Spec.Containers[0].Args = args
 		log.V(3).Info("The args", "args", deploy.Spec.Template.Spec.Containers[0].Args)
 	case res.CertManagerCainjectorName:
@@ -147,6 +150,7 @@ func setupDeploy(instance *operatorv1alpha1.CertManager, deploy *appsv1.Deployme
 		returningDeploy.Spec.Template.Spec.Containers[0].Image += instance.Spec.ImagePostFix
 	}
 
+	returningDeploy.Namespace = ns
 	log.V(2).Info("Resulting image registry", "full name", returningDeploy.Spec.Template.Spec.Containers[0].Image)
 	log.V(3).Info("Resulting deployment to be created", "spec", fmt.Sprintf("%v", returningDeploy))
 	return returningDeploy

--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -153,7 +153,7 @@ const webhookImage = imageRegistry + "/" + WebhookImageName + ":" + WebhookImage
 const configmapWatcherImage = imageRegistry + "/" + ConfigmapWatcherImageName + ":" + ConfigmapWatcherVersion
 
 // ServiceAccount is the name of the default service account to be used by cert-manager services
-const ServiceAccount = "default"
+const ServiceAccount = "cert-manager"
 
 // ClusterRoleName is the default name of the clusterrole and clusterrolebinding used by the cert-manager services
 const ClusterRoleName = "cert-manager"
@@ -193,21 +193,26 @@ var readinessExecActionConfigmapWatcher = v1.ExecAction{
 }
 
 // Cert-manager args
-const webhookServingSecret = "cert-manager-webhook-tls"
+
+// WebhookServingSecret is the name of tls secret used for serving the cert-manager-webhook
+const WebhookServingSecret = "cert-manager-webhook-tls"
 
 // ResourceNS is the resource namespace arg for cert-manager-controller
 const ResourceNS = "--cluster-resource-namespace=ibm-common-services"
+
 const leaderElectNS = "--leader-election-namespace=cert-manager"
 
 // AcmeSolverArg is the acme solver image to use for the cert-manager-controller
 const AcmeSolverArg = "--acme-http01-solver-image=" + acmesolverImage
+
 const webhookNSArg = "--webhook-namespace=" + DeployNamespace
 const webhookCASecretArg = "--webhook-ca-secret=cert-manager-webhook-ca"
-const webhookServingSecretArg = "--webhook-serving-secret=" + webhookServingSecret
+const webhookServingSecretArg = "--webhook-serving-secret=" + WebhookServingSecret
+
 const webhookDNSNamesArg = "--webhook-dns-names=cert-manager-webhook,cert-manager-webhook.cert-manager,cert-manager-webhook.cert-manager.svc"
 
 // DefaultArgs are the default arguments use for cert-manager-controller
-var DefaultArgs = []string{leaderElectNS, webhookNSArg, webhookCASecretArg, webhookServingSecretArg, webhookDNSNamesArg}
+var DefaultArgs = []string{webhookCASecretArg, webhookServingSecretArg}
 
 // CRDs is the list of crds created/used by cert-manager in this version
 var CRDs = [5]string{"certificates", "issuers", "clusterissuers", "orders", "challenges"}

--- a/pkg/resources/deployments.go
+++ b/pkg/resources/deployments.go
@@ -25,9 +25,9 @@ import (
 // ControllerDeployment is the deployment template for deploying the cert-manager-controller
 var ControllerDeployment = &appsv1.Deployment{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      CertManagerControllerName,
-		Namespace: DeployNamespace,
-		Labels:    ControllerLabelMap,
+		Name: CertManagerControllerName,
+		//		Namespace: DeployNamespace,
+		Labels: ControllerLabelMap,
 	},
 	Spec: appsv1.DeploymentSpec{
 		Replicas: &replicaCount,
@@ -47,8 +47,8 @@ var ControllerDeployment = &appsv1.Deployment{
 // WebhookDeployment is the deployment template for deploying the cert-manager-webhook
 var WebhookDeployment = &appsv1.Deployment{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:        CertManagerWebhookName,
-		Namespace:   DeployNamespace,
+		Name: CertManagerWebhookName,
+		//		Namespace:   DeployNamespace,
 		Labels:      WebhookLabelMap,
 		Annotations: webhookAnnotation,
 	},
@@ -74,9 +74,9 @@ var WebhookDeployment = &appsv1.Deployment{
 // CainjectorDeployment is the deployment template for deploying the cert-manager-cainjector
 var CainjectorDeployment = &appsv1.Deployment{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      CertManagerCainjectorName,
-		Namespace: DeployNamespace,
-		Labels:    CainjectorLabelMap,
+		Name: CertManagerCainjectorName,
+		//		Namespace: DeployNamespace,
+		Labels: CainjectorLabelMap,
 	},
 	Spec: appsv1.DeploymentSpec{
 		Replicas: &replicaCount,
@@ -96,9 +96,9 @@ var CainjectorDeployment = &appsv1.Deployment{
 // ConfigmapWatcherDeployment is the deployment spec for the configmap watcher
 var ConfigmapWatcherDeployment = &appsv1.Deployment{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      ConfigmapWatcherName,
-		Namespace: DeployNamespace,
-		Labels:    ConfigmapWatcherLabelMap,
+		Name: ConfigmapWatcherName,
+		//		Namespace: DeployNamespace,
+		Labels: ConfigmapWatcherLabelMap,
 	},
 	Spec: appsv1.DeploymentSpec{
 		Replicas: &replicaCount,

--- a/pkg/resources/rbac.go
+++ b/pkg/resources/rbac.go
@@ -25,8 +25,8 @@ import (
 // DefaultServiceAccount is the service account used by cert-manager service
 var DefaultServiceAccount = &corev1.ServiceAccount{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      ServiceAccount,
-		Namespace: DeployNamespace,
+		Name: ServiceAccount,
+		//		Namespace: DeployNamespace,
 	},
 }
 
@@ -123,10 +123,10 @@ var DefaultClusterRoleBinding = &rbacv1.ClusterRoleBinding{
 	},
 	Subjects: []rbacv1.Subject{
 		{
-			Kind:      "ServiceAccount",
-			APIGroup:  "",
-			Name:      ServiceAccount,
-			Namespace: DeployNamespace,
+			Kind:     "ServiceAccount",
+			APIGroup: "",
+			Name:     ServiceAccount,
+			//			Namespace: DeployNamespace,
 		},
 	},
 	RoleRef: rbacv1.RoleRef{

--- a/pkg/resources/webhook_resources.go
+++ b/pkg/resources/webhook_resources.go
@@ -77,7 +77,7 @@ var MutatingWebhook = &admRegv1beta1.MutatingWebhookConfiguration{
 	},
 }
 
-const injectSecretCA = DeployNamespace + "/" + webhookServingSecret
+//const injectSecretCA = DeployNamespace + "/" + webhookServingSecret
 
 // APISvcName is the name used for cert-manager-webhooks' apiservice definition
 const APISvcName = "v1beta1.webhook.certmanager.k8s.io"
@@ -90,7 +90,7 @@ var APIService = &apiRegv1.APIService{
 			"app": "ibm-cert-manager-webhook",
 		},
 		Annotations: map[string]string{
-			"certmanager.k8s.io/inject-ca-from-secret": injectSecretCA,
+			//"certmanager.k8s.io/inject-ca-from-secret": injectSecretCA,
 		},
 	},
 	Spec: apiRegv1.APIServiceSpec{
@@ -98,8 +98,8 @@ var APIService = &apiRegv1.APIService{
 		GroupPriorityMinimum: 1000,
 		VersionPriority:      15,
 		Service: &apiRegv1.ServiceReference{
-			Name:      CertManagerWebhookName,
-			Namespace: DeployNamespace,
+			Name: CertManagerWebhookName,
+			//Namespace: DeployNamespace,
 		},
 		Version: "v1beta1",
 	},
@@ -108,8 +108,8 @@ var APIService = &apiRegv1.APIService{
 // WebhookSvc is the service definition for cert-manager-webhook
 var WebhookSvc = &corev1.Service{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      CertManagerWebhookName,
-		Namespace: DeployNamespace,
+		Name: CertManagerWebhookName,
+		//Namespace: DeployNamespace,
 		Labels: map[string]string{
 			"app": "ibm-cert-manager-webhook",
 		},


### PR DESCRIPTION
Due to the inability to remove our CR (cluster-scoped) by removing a subscription/csv (namespace-scoped), our resources are unable to be cleaned up when we're uninstalled by the ODLM. 

This places all the resource cert-manager-operator creates (deploys, service accounts, etc.) into the same namespace that the cert-manager-operator is deployed in to make it easy for ODLM to clean up the resources.