### PR TITLE
Update design doc and adoption guide doc

### DIFF
--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -14,12 +14,33 @@ Previously, when all the services were deployed as helm charts, it was easy to u
 ## How to do it
 
 There are two ways to create cert-manager resources in your operator:
+1. [Preqrequisites](#pre)
 1. [As Go code](#go)
 1. [As yaml](#yaml)
 
-**NOTE**: There's RBAC that is required to create/read/upate/delete the cert-manager custom resources such as Certificates and Issuers. This permission will be created automatically for common services by cert-manager in 1Q and added to every service account in the common services namespace that our operators are deployed in.
+### Prerequisites
 
-## Go Code
+{: #pre}
+
+1. In your operator's `Role` (most commonly found in `deploy/role.yaml` in your operator's directory), add the following so that your operator has permission to create/read/update/delete cert-manager Certificate resources.
+
+    ````
+    rules:
+    - apiGroup: 
+      - certmanager.k8s.io
+      resources:
+      - certificates
+      verbs:
+      - create
+      - get
+      - update
+      - delete
+      - patch
+      - list
+      - watch
+    ````
+
+### Go Code
 
 {: #go}
 
@@ -147,11 +168,11 @@ There are two ways to create cert-manager resources in your operator:
         }
         ````
 
-### Live Example
+#### Live Example
 
 Can be found in [ibm-cert-manager-operator](http://github.com/Crystal-Chun/ibm-cert-manager-operator/tree/test-certmanager)
 
-## Yaml
+### Yaml
 
 {: #yaml}
 
@@ -279,7 +300,7 @@ Credits to @chenzhiwei for coming up with this.
     }
     ````
 
-### Example
+#### Example
 
 Courtesy of @chenzhiwei: [ibm-mongodb-operator](https://github.com/IBM/ibm-mongodb-operator/pull/28/files)
 
@@ -307,8 +328,7 @@ This scenario was fine because:
 {: #problem}
 
 Now with moving to operators:
-1. The meta-operator doesn't create this Root CA certificate anymore
-1. Even if we do still create a shared ClusterIssuer, each operator needs to have permission to use it which requires cluster-scoped permissions
+1. The ODLM doesn't create this Root CA certificate anymore
 
 ### Proposed Solution
 
@@ -316,20 +336,16 @@ Now with moving to operators:
 
 We've thought of multiple ways to handle the problems faced above and this is our proposed solution to it.
 
-1. We (cert-manager) will take responsibility of creating the Root CA certificate which will be available in a Secret (K8s resource) to be used.
+1. We (cert-manager) will take responsibility of creating the common CA ClusterIssuer shared amongst the common services.
     - This is generated DIFFERENTLY than how the icp-inception installer created it
-        - Essentially, we will create a self-signed Issuer (cert-manager resource), create a Certificate (cert-manager resource) that is a CA certificate with a well-known Secret name.
-    - The result is similar to how the `cluster-ca-cert` was the secret backing the ClusterIssuer `icp-ca-issuer`
-    - The exact secret name is still to be determined -> Suggestion is `common-services-ca-secret`
+        - Essentially, we will create a self-signed Issuer (cert-manager resource), create a Certificate (cert-manager resource) that is a CA certificate with a well-known Secret name, and then create a CA ClusterIssuer from that CA certificate.
+    - The result is a ClusterIssuer called `cs-ca-clusterissuer` which is identical to the `icp-ca-issuer`.
     - This has some benefits such as
         - Support from cert-manager for automatic refreshing of the CA certificate when it expires
         - The ability to manually refresh it easily by deleting the secret.
         - The ability to BYO CA by replacing this secret and deleting the cert-manager Certificate
-    - This mitigates the first problem
-1. Each operator will need to create their own CA Issuer (cert-manager resource) to sign their Certificates based off of the Secret (containing the generated CA certificate) in the first point.
-    - Notice this is NOT a ClusterIssuer
-    - There's a potential problem here if every common service is creating their own Issuer if the name of that Issuer clash, that could be a problem
-1. We (cert-manager) will take the responsibility of tying the service accounts in the common services namespace to a role that allows the services to create/read/update/delete cert-manager resources (Certificates and Issuers).
+1. Each operator will just need to create their Certificates (cert-manager resource) signed by the common CA ClusterIssuer.
+    - See steps below
 
 ### Steps
 
@@ -337,35 +353,7 @@ We've thought of multiple ways to handle the problems faced above and this is ou
 
 To adopt the solution, each operator must:
 
-1. Create a CA Issuer (cert-manager resource) referencing the well-known CA certificate Secret's name.
-    - Example go code (see yaml example above if you wish to do it that way):
-
-        ````
-            log.Info("Creating cert manager issuer")
-            issuer := &certmgr.Issuer{
-            ObjectMeta: metav1.ObjectMeta{
-                Name:      "my-ca-issuer",
-                Namespace: "ibm-common-services",
-            },
-            Spec: certmgr.IssuerSpec{
-                        IssuerConfig: certmgr.IssuerConfig{
-                            CA: &certmgr.CAIssuer{
-                                SecretName: "common-services-ca-secret",
-                            },
-                        },
-                    },
-            }
-
-            if err := r.client.Create(context.TODO(), issuer); err != nil {
-                    log.Error(err, "Error creating cert-manager issuer")
-                    return err
-            }
-            return nil
-        ````
-
-            - Notice how the `SecretName` is `common-services-ca-secret` -> This name will be provided by us, and this is the proposed name. This can change within the next two weeks.
-            - Notice the `Name` of your Issuer. It should not clash with the Issuer name of others in the same namespace.
-1. Create your Certificate (cert-manager resource) using the Issuer you created in step 1 as its issuerRef.
+1. Create your Certificate (cert-manager resource) using the common CA ClusterIssuer that's predefined.
     - Example go code (see yaml example above if you wish to do it that way):
 
         ````
@@ -377,8 +365,8 @@ To adopt the solution, each operator must:
                 Spec: certmgr.CertificateSpec{
                     SecretName: "my-secret",
                     IssuerRef: certmgr.ObjectReference{
-                        Name: "my-ca-issuer",
-                        Kind: "Issuer",
+                        Name: "cs-ca-clusterissuer",
+                        Kind: "ClusterIssuer",
                     },
                     CommonName: "my-service-name",
                 },

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -28,7 +28,7 @@ There are two options to create cert-manager resources in your operator:
 
     ````
     rules:
-    - apiGroup: 
+    - apiGroup:
       - certmanager.k8s.io
       resources:
       - certificates

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -13,8 +13,10 @@ Previously, when all the services were deployed as helm charts, it was easy to u
 
 ## How to do it
 
-There are two ways to create cert-manager resources in your operator:
+Fulfill the prerequisites:
 1. [Preqrequisites](#pre)
+
+There are two options to create cert-manager resources in your operator:
 1. [As Go code](#go)
 1. [As yaml](#yaml)
 

--- a/docs/design-spec.md
+++ b/docs/design-spec.md
@@ -11,10 +11,6 @@
         - if they exist, continue
         - if they do not exist, try to create them
             - if there's errors creating them, requeue and try again
-    1. Check the cert-manager namespace exists
-        - if it exists, continue
-        - if it does not exist, create it
-            - if there's an error creating it, requeue and try again
     1. Check RBAC is in place for cert-manager
         - Check roles
             - Clusterrole
@@ -28,6 +24,9 @@
             - Create the service account ignoring errors if it already exists
                 - if there's an error that's not related to it already existing, requeue and try again
     1. Check the deployment
+        - If an instance of cert-manager already exists
+            - Create a warning status on the CertManager CR telling them one exists and to remove it before proceeding and requeue and try again
+        - If an instance of cert-manager does not already exist, continue
         - If the cert-manager deployment exists
             - if it does, check if anything differs from the template
                 - if it does send an update using the template
@@ -65,7 +64,6 @@
         - RBAC
             - Removes clusterrolebinding
             - Removes the clusterrole
-            - Removes the imagepullsecret - if it was copied over by this operator
             - Removes webhook rolebinding
         - Deployments
             - webhook deploy
@@ -76,6 +74,7 @@
         - Mutating Webhook Configuration
         - Service
         - API Service
+        - Cert-manager CRDS (certificates, issuers, clusterissuers, orders, and challenges)
         - NOTE: the finalizer automatically removes resources created by this operator. If any of these were not created by operator and were already present in the system then the operator will not remove them upon CR removal.
     1. Remove the finalizer from list of finalizers on CR
 


### PR DESCRIPTION
Design doc:
- added the logic for if an instance of cert-manager exists
- removed the part about image pull secrets

Adoption guide:
- Updated guide based on recent discussion