### PR TITLE
Fix logic handling image registry

### DIFF
--- a/pkg/controller/certmanager/deploys.go
+++ b/pkg/controller/certmanager/deploys.go
@@ -110,11 +110,7 @@ func setupDeploy(instance *operatorv1alpha1.CertManager, deploy *appsv1.Deployme
 
 	imageRegistry := res.ImageRegistry
 	if instance.Spec.ImageRegistry != "" {
-		imageRegistry = instance.Spec.ImageRegistry
-		// Remove forward slash
-		if imageRegistry[len(imageRegistry)-1] == '/' {
-			imageRegistry = imageRegistry[:len(imageRegistry)-1]
-		}
+		imageRegistry = strings.TrimRight(instance.Spec.ImageRegistry, "/")
 	}
 	switch deploy.Name {
 	case res.CertManagerControllerName:

--- a/pkg/controller/certmanager/deploys.go
+++ b/pkg/controller/certmanager/deploys.go
@@ -108,14 +108,19 @@ func setupDeploy(instance *operatorv1alpha1.CertManager, deploy *appsv1.Deployme
 
 	returningDeploy := *deploy
 
+	imageRegistry := res.ImageRegistry
+	if instance.Spec.ImageRegistry != "" {
+		imageRegistry = instance.Spec.ImageRegistry
+		// Remove forward slash
+		if imageRegistry[len(imageRegistry)-1] == '/' {
+			imageRegistry = imageRegistry[:len(imageRegistry)-1]
+		}
+	}
 	switch deploy.Name {
 	case res.CertManagerControllerName:
-		var acmesolver = res.AcmeSolverArg
-		if instance.Spec.ImageRegistry != "" { // Set the image registry to the one specified
-			// Assume image registry doesn't have forward slash at the end
-			returningDeploy.Spec.Template.Spec.Containers[0].Image = instance.Spec.ImageRegistry + "/" + res.ControllerImageName + ":" + res.ControllerImageVersion
-			acmesolver = "--acme-http01-solver-image=" + instance.Spec.ImageRegistry + "/" + res.AcmesolverImageName + ":" + res.ControllerImageVersion
-		}
+		returningDeploy.Spec.Template.Spec.Containers[0].Image = imageRegistry + "/" + res.ControllerImageName + ":" + res.ControllerImageVersion
+		var acmesolver = "--acme-http01-solver-image=" + imageRegistry + "/" + res.AcmesolverImageName + ":" + res.ControllerImageVersion
+
 		var resourceNS = res.ResourceNS
 		if instance.Spec.ResourceNS != "" {
 			resourceNS = "--cluster-resource-namespace=" + instance.Spec.ResourceNS
@@ -129,21 +134,12 @@ func setupDeploy(instance *operatorv1alpha1.CertManager, deploy *appsv1.Deployme
 		returningDeploy.Spec.Template.Spec.Containers[0].Args = args
 		log.V(3).Info("The args", "args", deploy.Spec.Template.Spec.Containers[0].Args)
 	case res.CertManagerCainjectorName:
-		if instance.Spec.ImageRegistry != "" { // Set the image registry to the one specified
-			// Assume image registry doesn't have forward slash at the end
-			returningDeploy.Spec.Template.Spec.Containers[0].Image = instance.Spec.ImageRegistry + "/" + res.CainjectorImageName + ":" + res.ControllerImageVersion
-		}
+		returningDeploy.Spec.Template.Spec.Containers[0].Image = imageRegistry + "/" + res.CainjectorImageName + ":" + res.ControllerImageVersion
 	case res.CertManagerWebhookName:
-		if instance.Spec.ImageRegistry != "" { // Set the image registry to the one specified
-			// Assume image registry doesn't have forward slash at the end
-			returningDeploy.Spec.Template.Spec.Containers[0].Image = instance.Spec.ImageRegistry + "/" + res.WebhookImageName + ":" + res.WebhookImageVersion
-			returningDeploy.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem = &res.FalseVar
-		}
+		returningDeploy.Spec.Template.Spec.Containers[0].Image = imageRegistry + "/" + res.WebhookImageName + ":" + res.WebhookImageVersion
+		returningDeploy.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem = &res.FalseVar
 	case res.ConfigmapWatcherName:
-		if instance.Spec.ImageRegistry != "" { // Set the image registry to the one specified
-			// Assume image registry doesn't have forward slash at the end
-			returningDeploy.Spec.Template.Spec.Containers[0].Image = instance.Spec.ImageRegistry + "/" + res.ConfigmapWatcherImageName + ":" + res.ConfigmapWatcherVersion
-		}
+		returningDeploy.Spec.Template.Spec.Containers[0].Image = imageRegistry + "/" + res.ConfigmapWatcherImageName + ":" + res.ConfigmapWatcherVersion
 	}
 
 	if instance.Spec.ImagePostFix != "" {

--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -101,7 +101,7 @@ const CainjectorLabels = "app=ibm-cert-manager-cainjector"
 const ConfigmapWatcherLabels = "app.kubernetes.io/name=configmap-watcher"
 
 // DeployNamespace is the namespace the cert-manager services will be deployed in
-const DeployNamespace = "cert-manager"
+const DeployNamespace = "ibm-common-services"
 const pullPolicy = v1.PullIfNotPresent
 
 // CertManagerControllerName is the name of the container/pod/deployment for cert-manager-controller
@@ -119,8 +119,8 @@ const CertManagerWebhookName = "cert-manager-webhook"
 // ConfigmapWatcherName is the name of the container/pod/deployment for the configmap-watcher
 const ConfigmapWatcherName = "configmap-watcher"
 
-// Default Image Values
-const imageRegistry = "quay.io"
+// ImageRegistry is the default image registry for the operand deployments
+const ImageRegistry = "quay.io"
 
 // ControllerImageVersion is the image version used for the cert-manager-controller
 const ControllerImageVersion = "0.10.3"
@@ -146,11 +146,11 @@ const WebhookImageName = "icp-cert-manager-webhook"
 // ConfigmapWatcherImageName is the name of the configmap watcher image
 const ConfigmapWatcherImageName = "icp-configmap-watcher"
 
-const controllerImage = imageRegistry + "/" + ControllerImageName + ":" + ControllerImageVersion
-const acmesolverImage = imageRegistry + "/" + AcmesolverImageName + ":" + ControllerImageVersion
-const cainjectorImage = imageRegistry + "/" + CainjectorImageName + ":" + ControllerImageVersion
-const webhookImage = imageRegistry + "/" + WebhookImageName + ":" + WebhookImageVersion
-const configmapWatcherImage = imageRegistry + "/" + ConfigmapWatcherImageName + ":" + ConfigmapWatcherVersion
+const controllerImage = ImageRegistry + "/" + ControllerImageName + ":" + ControllerImageVersion
+const acmesolverImage = ImageRegistry + "/" + AcmesolverImageName + ":" + ControllerImageVersion
+const cainjectorImage = ImageRegistry + "/" + CainjectorImageName + ":" + ControllerImageVersion
+const webhookImage = ImageRegistry + "/" + WebhookImageName + ":" + WebhookImageVersion
+const configmapWatcherImage = ImageRegistry + "/" + ConfigmapWatcherImageName + ":" + ConfigmapWatcherVersion
 
 // ServiceAccount is the name of the default service account to be used by cert-manager services
 const ServiceAccount = "cert-manager"


### PR DESCRIPTION
Previously did not account for having a forward slash when `imageRegistry` is specified. This logic takes care of it by removing it (no matter how many there are) to standardize the imageRegistry variable. 