### PR TITLE
Use the correct configmap watcher version.

### DIFF
--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -129,7 +129,7 @@ const ControllerImageVersion = "0.10.3"
 const WebhookImageVersion = "0.10.3"
 
 // ConfigmapWatcherVersion is the image version used for the configmap-watcher
-const ConfigmapWatcherVersion = "3.3.0"
+const ConfigmapWatcherVersion = "3.3.1"
 
 // ControllerImageName is the image name of the cert-manager-controller
 const ControllerImageName = "icp-cert-manager-controller"


### PR DESCRIPTION
The latest version is `3.3.1` https://github.ibm.com/IBMPrivateCloud/configmap-watcher/blob/master/RELEASE_VERSION