### PR TITLE
Prevent removing additional deployment labels

### DIFF
--- a/pkg/controller/certmanager/deploys.go
+++ b/pkg/controller/certmanager/deploys.go
@@ -213,7 +213,7 @@ func deployFinder(client kubernetes.Interface, labels, name string) []appsv1.Dep
 // true otherwise
 func equalDeploys(first, second appsv1.Deployment) bool {
 	statusLog := log.V(1)
-	if !reflect.DeepEqual(first.ObjectMeta.Labels, second.ObjectMeta.Labels) {
+	if !reflect.DeepEqual(first.ObjectMeta.Labels, second.ObjectMeta.Labels) && !isSubset(first.ObjectMeta.Labels, second.ObjectMeta.Labels) {
 		statusLog.Info("Labels not equal",
 			"first", fmt.Sprintf("%v", first.ObjectMeta.Labels),
 			"second", fmt.Sprintf("%v", second.ObjectMeta.Labels))
@@ -536,5 +536,18 @@ func equalDeploys(first, second appsv1.Deployment) bool {
 	}
 
 	log.V(2).Info("Finished checking for differences between the deployments and found none.", "deployment name", first.Name)
+	return true
+}
+
+func isSubset(first, second map[string]string) bool {
+	for k, v := range first {
+		if val, ok := second[k]; !ok {
+			return false
+		} else {
+			if v != val {
+				return false
+			}
+		}
+	}
 	return true
 }

--- a/pkg/controller/certmanager/deploys.go
+++ b/pkg/controller/certmanager/deploys.go
@@ -87,6 +87,7 @@ func deployLogic(instance *operatorv1alpha1.CertManager, client client.Client, k
 	} else {
 		if !equalDeploys(deployment, existingDeploy) {
 			// Update
+			log.V(1).Info("Deploys not equal!!!!!!!!!!!!!!")
 			log.V(2).Info("Updating deployment")
 			if err := client.Update(context.Background(), &deployment); err != nil {
 				return err
@@ -227,7 +228,7 @@ func equalDeploys(first, second appsv1.Deployment) bool {
 
 	firstPodTemplate := first.Spec.Template
 	secondPodTemplate := second.Spec.Template
-	if !reflect.DeepEqual(firstPodTemplate.ObjectMeta.Labels, secondPodTemplate.ObjectMeta.Labels) {
+	if !isSubset(firstPodTemplate.ObjectMeta.Labels, secondPodTemplate.ObjectMeta.Labels) {
 		statusLog.Info("Pod labels not equal",
 			"first", fmt.Sprintf("%v", firstPodTemplate.ObjectMeta.Labels),
 			"second", fmt.Sprintf("%v", secondPodTemplate.ObjectMeta.Labels))
@@ -540,14 +541,18 @@ func equalDeploys(first, second appsv1.Deployment) bool {
 }
 
 func isSubset(first, second map[string]string) bool {
+	log.Info("in subset")
 	for k, v := range first {
-		if val, ok := second[k]; !ok {
+		val, ok := second[k]
+		if !ok {
+			log.Info("couldn't find key", "k", k)
 			return false
-		} else {
-			if v != val {
-				return false
-			}
 		}
+		if v != val {
+			log.Info("val wasn't same", "v", v, "val", val)
+			return false
+		}
+
 	}
 	return true
 }

--- a/pkg/controller/certmanager/deploys.go
+++ b/pkg/controller/certmanager/deploys.go
@@ -87,7 +87,6 @@ func deployLogic(instance *operatorv1alpha1.CertManager, client client.Client, k
 	} else {
 		if !equalDeploys(deployment, existingDeploy) {
 			// Update
-			log.V(1).Info("Deploys not equal!!!!!!!!!!!!!!")
 			log.V(2).Info("Updating deployment")
 			if err := client.Update(context.Background(), &deployment); err != nil {
 				return err
@@ -541,15 +540,14 @@ func equalDeploys(first, second appsv1.Deployment) bool {
 }
 
 func isSubset(first, second map[string]string) bool {
-	log.Info("in subset")
 	for k, v := range first {
 		val, ok := second[k]
 		if !ok {
-			log.Info("couldn't find key", "k", k)
+			log.V(2).Info("Key doesn't exist in the second map", "k", k)
 			return false
 		}
 		if v != val {
-			log.Info("val wasn't same", "v", v, "val", val)
+			log.V(2).Info("Values aren't equal", "v", v, "val", val)
 			return false
 		}
 

--- a/pkg/controller/certmanager/deploys.go
+++ b/pkg/controller/certmanager/deploys.go
@@ -213,7 +213,7 @@ func deployFinder(client kubernetes.Interface, labels, name string) []appsv1.Dep
 // true otherwise
 func equalDeploys(first, second appsv1.Deployment) bool {
 	statusLog := log.V(1)
-	if !reflect.DeepEqual(first.ObjectMeta.Labels, second.ObjectMeta.Labels) && !isSubset(first.ObjectMeta.Labels, second.ObjectMeta.Labels) {
+	if !isSubset(first.ObjectMeta.Labels, second.ObjectMeta.Labels) {
 		statusLog.Info("Labels not equal",
 			"first", fmt.Sprintf("%v", first.ObjectMeta.Labels),
 			"second", fmt.Sprintf("%v", second.ObjectMeta.Labels))


### PR DESCRIPTION
When a deployment is updated with additional labels, such as when the configmap-watcher restarts its pods, the operator will not accept the additional labels and immediately remove the update deployment. 


This PR changes the logic to check to see if the labels the deployment should have is a subset of the ones the deployment actually has. In other words, the labels of the deployment must minimally contain the labels it expects.