### PR TITLE
Added additional field to determine if it's ocp 3.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ multiarch-image:
 # CSV section
 ############################################################
 csv:
-	@RELEASE=${CSV_VERSION} common/scripts/push_csv.sh
+	common/scripts/push_csv.sh
 
 ############################################################
 # clean section

--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -199,7 +199,7 @@ issues:
     - line is 181 characters
     - line is 210 characters
     - line is 316 characters
-    - cyclomatic complexity 96 
+    - cyclomatic complexity 97 
 
   exclude-rules:
     # Exclude some linters from running on test files.

--- a/deploy/crds/operator.ibm.com_certmanagers_crd.yaml
+++ b/deploy/crds/operator.ibm.com_certmanagers_crd.yaml
@@ -41,6 +41,8 @@ spec:
                 modifying this file Add custom validation using kubebuilder tags:
                 https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: string
+            ocp311:
+              type: boolean
             resourceNamespace:
               type: string
           type: object

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v3.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v3.5.0.clusterserviceversion.yaml
@@ -142,6 +142,11 @@ spec:
         path: imageRegistry
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: Determines whether it's an ocp 3.11 environment
+        displayName: OCP3111
+        path: ocp311
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
       - description: The namespace where namespace scoped resources referenced by cert-manager clusterissuers must be placed
         displayName: ResourceNamespace
         path: resourceNamespace

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/operator.ibm.com_certmanagers_crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/operator.ibm.com_certmanagers_crd.yaml
@@ -41,6 +41,8 @@ spec:
                 modifying this file Add custom validation using kubebuilder tags:
                 https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: string
+            ocp311:
+              type: boolean
             resourceNamespace:
               type: string
           type: object

--- a/pkg/apis/operator/v1alpha1/certmanager_types.go
+++ b/pkg/apis/operator/v1alpha1/certmanager_types.go
@@ -32,6 +32,7 @@ type CertManagerSpec struct {
 	ImagePostFix  string `json:"imagePostFix,omitempty"`
 	Webhook       bool   `json:"enableWebhook,omitempty"`
 	ResourceNS    string `json:"resourceNamespace,omitempty"`
+	OCP311        bool   `json:"ocp311,omitempty"`
 }
 
 // CertManagerStatus defines the observed state of CertManager

--- a/pkg/controller/certmanager/deploys.go
+++ b/pkg/controller/certmanager/deploys.go
@@ -134,6 +134,10 @@ func setupDeploy(instance *operatorv1alpha1.CertManager, deploy *appsv1.Deployme
 	case res.CertManagerWebhookName:
 		returningDeploy.Spec.Template.Spec.Containers[0].Image = imageRegistry + "/" + res.WebhookImageName + ":" + res.WebhookImageVersion
 		returningDeploy.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem = &res.FalseVar
+		if instance.Spec.OCP311 {
+			log.Info("Ocp 311 spec set")
+			returningDeploy.Spec.Template.Spec.HostNetwork = res.FalseVar
+		}
 	case res.ConfigmapWatcherName:
 		returningDeploy.Spec.Template.Spec.Containers[0].Image = imageRegistry + "/" + res.ConfigmapWatcherImageName + ":" + res.ConfigmapWatcherVersion
 	}
@@ -278,6 +282,11 @@ func equalDeploys(first, second appsv1.Deployment) bool {
 		}
 	} else {
 		statusLog.Info("Volume lengths not equal")
+		return false
+	}
+
+	if firstPodTemplate.Spec.HostNetwork != secondPodTemplate.Spec.HostNetwork {
+		statusLog.Info("Host networks are not equal")
 		return false
 	}
 

--- a/pkg/controller/certmanager/deploys.go
+++ b/pkg/controller/certmanager/deploys.go
@@ -135,7 +135,6 @@ func setupDeploy(instance *operatorv1alpha1.CertManager, deploy *appsv1.Deployme
 		returningDeploy.Spec.Template.Spec.Containers[0].Image = imageRegistry + "/" + res.WebhookImageName + ":" + res.WebhookImageVersion
 		returningDeploy.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem = &res.FalseVar
 		if instance.Spec.OCP311 {
-			log.Info("Ocp 311 spec set")
 			returningDeploy.Spec.Template.Spec.HostNetwork = res.FalseVar
 		}
 	case res.ConfigmapWatcherName:


### PR DESCRIPTION
In OCP 3.11 the webhook can't be deployed using hostNetwork because the apiserver will fail to contact it. This mitigates the issue by setting it to false when it's ocp 3.11. The CertManager CRD now looks like this:
````
- apiVersion: operator.ibm.com/v1alpha1
  kind: CertManager
  metadata:
    name: default
  spec:
    enableWebhook: true
    imageRegistry: registry.mixhub.cn/integration/
    ocp311: true
````

The hostNetwork is needed for OCP 4.x to be discovered by the apiserver.