### PR TITLE
Add the exact repo to pull from in the default example CR.

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml
@@ -4,6 +4,6 @@ metadata:
   name: default
 spec:
   enableWebhook: true
-  imageRegistry: quay.io
+  imageRegistry: quay.io/opencloudio
 status:
   certManagerStatus: {}

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v3.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v3.5.0.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
           },
           "spec": {
             "enableWebhook": true,
-            "imageRegistry": "quay.io"
+            "imageRegistry": "quay.io/opencloudio"
           },
           "status": {
             "certManagerStatus": {}


### PR DESCRIPTION
From testing a default install (no customizations). The operand images are located in this repo.