### PR TITLE
Renaming field ocp311 to disableHostNetwork

### DIFF
--- a/deploy/crds/operator.ibm.com_certmanagers_crd.yaml
+++ b/deploy/crds/operator.ibm.com_certmanagers_crd.yaml
@@ -31,6 +31,8 @@ spec:
         spec:
           description: CertManagerSpec defines the desired state of CertManager
           properties:
+            disableHostNetwork:
+              type: boolean
             enableWebhook:
               type: boolean
             imagePostFix:
@@ -41,8 +43,6 @@ spec:
                 modifying this file Add custom validation using kubebuilder tags:
                 https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: string
-            ocp311:
-              type: boolean
             resourceNamespace:
               type: string
           type: object

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v3.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/ibm-cert-manager-operator.v3.5.0.clusterserviceversion.yaml
@@ -127,6 +127,11 @@ spec:
         name: apiservices.apiregistration.k8s.io
         version: v1
       specDescriptors:
+      - description: Disables the use of hostNetwork by the webhook
+        displayName: DisableHostNetwork
+        path: disableHostNetwork
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
       - description: Enables the webhook component of cert-manager when set to true
         displayName: EnableWebhook
         path: enableWebhook
@@ -140,11 +145,6 @@ spec:
       - description: Sets the image registry to this when deploying cert-manager
         displayName: ImageRegistry
         path: imageRegistry
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:text'
-      - description: Determines whether it's an ocp 3.11 environment
-        displayName: OCP3111
-        path: ocp311
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:text'
       - description: The namespace where namespace scoped resources referenced by cert-manager clusterissuers must be placed

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/operator.ibm.com_certmanagers_crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.5.0/operator.ibm.com_certmanagers_crd.yaml
@@ -31,6 +31,8 @@ spec:
         spec:
           description: CertManagerSpec defines the desired state of CertManager
           properties:
+            disableHostNetwork:
+              type: boolean
             enableWebhook:
               type: boolean
             imagePostFix:
@@ -41,8 +43,6 @@ spec:
                 modifying this file Add custom validation using kubebuilder tags:
                 https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: string
-            ocp311:
-              type: boolean
             resourceNamespace:
               type: string
           type: object

--- a/pkg/apis/operator/v1alpha1/certmanager_types.go
+++ b/pkg/apis/operator/v1alpha1/certmanager_types.go
@@ -28,11 +28,11 @@ type CertManagerSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
-	ImageRegistry string `json:"imageRegistry,omitempty"`
-	ImagePostFix  string `json:"imagePostFix,omitempty"`
-	Webhook       bool   `json:"enableWebhook,omitempty"`
-	ResourceNS    string `json:"resourceNamespace,omitempty"`
-	OCP311        bool   `json:"ocp311,omitempty"`
+	ImageRegistry      string `json:"imageRegistry,omitempty"`
+	ImagePostFix       string `json:"imagePostFix,omitempty"`
+	Webhook            bool   `json:"enableWebhook,omitempty"`
+	ResourceNS         string `json:"resourceNamespace,omitempty"`
+	DisableHostNetwork bool   `json:"disableHostNetwork,omitempty"`
 }
 
 // CertManagerStatus defines the observed state of CertManager

--- a/pkg/controller/certmanager/deploys.go
+++ b/pkg/controller/certmanager/deploys.go
@@ -134,7 +134,7 @@ func setupDeploy(instance *operatorv1alpha1.CertManager, deploy *appsv1.Deployme
 	case res.CertManagerWebhookName:
 		returningDeploy.Spec.Template.Spec.Containers[0].Image = imageRegistry + "/" + res.WebhookImageName + ":" + res.WebhookImageVersion
 		returningDeploy.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem = &res.FalseVar
-		if instance.Spec.OCP311 {
+		if instance.Spec.DisableHostNetwork {
 			returningDeploy.Spec.Template.Spec.HostNetwork = res.FalseVar
 		}
 	case res.ConfigmapWatcherName:


### PR DESCRIPTION
Renaming `ocp311` field to `disableHostNetwork`. 
This is because the webhook issue related to hostNetwork exists not just for OCP 3.11 but also for 4.4.
 
Solved Webhook error:
```
kubectl api-resources
error: unable to retrieve the complete list of server APIs: webhook.certmanager.k8s.io/v1beta1: the server is currently unable to handle the request
```