### PR TITLE
Generate CSV for 3.6.0 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,4 +196,44 @@ csv:
 clean:
 	rm -f build/_output
 
+############################################################
+# application section
+############################################################
+
+install: ## Install all resources (CR/CRD's, RBAC and Operator)
+	@echo ....... Set environment variables ......
+	- export DEPLOY_DIR=deploy/crds
+	- export WATCH_NAMESPACE=${NAMESPACE}
+	# @echo ....... Creating namespace .......
+	# - kubectl create namespace ${NAMESPACE}
+	@echo ....... Applying CRDS and Operator .......
+	- for crd in $(shell ls deploy/crds/*crd.yaml); do kubectl apply -f $${crd}; done
+	@echo ....... Applying RBAC .......
+	- kubectl apply -f deploy/service_account.yaml -n ${NAMESPACE}
+	- kubectl apply -f deploy/role.yaml -n ${NAMESPACE}
+	- kubectl apply -f deploy/role_binding.yaml -n ${NAMESPACE}
+	- kubectl apply -f deploy/access-role.yaml -n ${NAMESPACE}
+	- kubectl apply -f deploy/access-rolebinding.yaml -n ${NAMESPACE}
+	@echo ....... Applying Operator .......
+	- kubectl apply -f deploy/olm-catalog/${BASE_DIR}/${CSV_VERSION}/${BASE_DIR}.v${CSV_VERSION}.clusterserviceversion.yaml -n ${NAMESPACE}
+	@echo ....... Creating the Instance .......
+	- for cr in $(shell ls deploy/crds/*_cr.yaml); do kubectl -n ${NAMESPACE} apply -f $${cr}; done
+
+uninstall: ## Uninstall all that all performed in the $ make install
+	@echo ....... Uninstalling .......
+	@echo ....... Deleting CR .......
+	- for cr in $(shell ls deploy/crds/*_cr.yaml); do kubectl -n ${NAMESPACE} delete -f $${cr}; done
+	@echo ....... Deleting Operator .......
+	- kubectl delete -f deploy/olm-catalog/${BASE_DIR}/${CSV_VERSION}/${BASE_DIR}.v${CSV_VERSION}.clusterserviceversion.yaml -n ${NAMESPACE}
+	@echo ....... Deleting CRDs.......
+	- for crd in $(shell ls deploy/crds/*crd.yaml); do kubectl delete -f $${crd}; done
+	@echo ....... Deleting Rules and Service Account .......
+	- kubectl delete -f deploy/role_binding.yaml -n ${NAMESPACE}
+	- kubectl delete -f deploy/service_account.yaml -n ${NAMESPACE}
+	- kubectl delete -f deploy/role.yaml -n ${NAMESPACE}
+	- kubectl delete -f deploy/access-role.yaml -n ${NAMESPACE}
+	- kubectl delete -f deploy/access-rolebinding.yaml -n ${NAMESPACE}
+	# @echo ....... Deleting namespace .......
+	# - kubectl delete namespace ${NAMESPACE}
+
 .PHONY: all work build check lint test coverage images multiarch-image

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.6.0/certificate-crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.6.0/certificate-crd.yaml
@@ -1,0 +1,299 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.certmanager.k8s.io
+  labels:
+    app.kubernetes.io/instance: ibm-cert-manager-operator
+    app.kubernetes.io/managed-by: ibm-cert-manager-operator
+    app.kubernetes.io/name: cert-manager
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - JSONPath: .spec.secretName
+      name: Secret
+      type: string
+    - JSONPath: .spec.issuerRef.name
+      name: Issuer
+      type: string
+      priority: 1
+    - JSONPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+      priority: 1
+    - JSONPath: .metadata.creationTimestamp
+      description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        \nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+      name: Age
+      type: date
+    - JSONPath: .status.notAfter
+      name: Expiration
+      type: string
+  group: certmanager.k8s.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: Certificate
+    plural: certificates
+    shortNames:
+      - cert
+      - certs
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: Certificate is a type to represent a Certificate from ACME
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CertificateSpec defines the desired state of Certificate
+          properties:
+            acme:
+              description: ACME contains configuration specific to ACME Certificates.
+                Notably, this contains details on how the domain names listed on this
+                Certificate resource should be 'solved', i.e. mapping HTTP01 and DNS01
+                providers to DNS names.
+              properties:
+                config:
+                  items:
+                    description: DomainSolverConfig contains solver configuration
+                      for a set of domains.
+                    properties:
+                      dns01:
+                        description: DNS01 contains DNS01 challenge solving configuration
+                        properties:
+                          provider:
+                            description: Provider is the name of the DNS01 challenge
+                              provider to use, as configure on the referenced Issuer
+                              or ClusterIssuer resource.
+                            type: string
+                        required:
+                        - provider
+                        type: object
+                      domains:
+                        description: Domains is the list of domains that this SolverConfig
+                          applies to.
+                        items:
+                          type: string
+                        type: array
+                      http01:
+                        description: HTTP01 contains HTTP01 challenge solving configuration
+                        properties:
+                          ingress:
+                            description: Ingress is the name of an Ingress resource
+                              that will be edited to include the ACME HTTP01 'well-known'
+                              challenge path in order to solve HTTP01 challenges.
+                              If this field is specified, 'ingressClass' **must not**
+                              be specified.
+                            type: string
+                          ingressClass:
+                            description: IngressClass is the ingress class that should
+                              be set on new ingress resources that are created in
+                              order to solve HTTP01 challenges. This field should
+                              be used when using an ingress controller such as nginx,
+                              which 'flattens' ingress configuration instead of maintaining
+                              a 1:1 mapping between loadbalancer IP:ingress resources.
+                              If this field is not set, and 'ingress' is not set,
+                              then ingresses without an ingress class set will be
+                              created to solve HTTP01 challenges. If this field is
+                              specified, 'ingress' **must not** be specified.
+                            type: string
+                        type: object
+                    required:
+                    - domains
+                    type: object
+                  type: array
+              required:
+              - config
+              type: object
+            commonName:
+              description: CommonName is a common name to be used on the Certificate.
+                If no CommonName is given, then the first entry in DNSNames is used
+                as the CommonName. The CommonName should have a length of 64 characters
+                or fewer to avoid generating invalid CSRs; in order to have longer
+                domain names, set the CommonName (or first DNSNames entry) to have
+                64 characters or fewer, and then add the longer domain name to DNSNames.
+              type: string
+            dnsNames:
+              description: DNSNames is a list of subject alt names to be used on the
+                Certificate. If no CommonName is given, then the first entry in DNSNames
+                is used as the CommonName and must have a length of 64 characters
+                or fewer.
+              items:
+                type: string
+              type: array
+            duration:
+              description: Certificate default Duration
+              type: string
+            ipAddresses:
+              description: IPAddresses is a list of IP addresses to be used on the
+                Certificate
+              items:
+                type: string
+              type: array
+            isCA:
+              description: IsCA will mark this Certificate as valid for signing. This
+                implies that the 'cert sign' usage is set
+              type: boolean
+            issuerRef:
+              description: IssuerRef is a reference to the issuer for this certificate.
+                If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                with the given name in the same namespace as the Certificate will
+                be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                with the provided name will be used. The 'name' field in this stanza
+                is required at all times.
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+            keyAlgorithm:
+              description: KeyAlgorithm is the private key algorithm of the corresponding
+                private key for this certificate. If provided, allowed values are
+                either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
+                not provided, key size of 256 will be used for "ecdsa" key algorithm
+                and key size of 2048 will be used for "rsa" key algorithm.
+              enum:
+              - rsa
+              - ecdsa
+              type: string
+            keyEncoding:
+              description: KeyEncoding is the private key cryptography standards (PKCS)
+                for this certificate's private key to be encoded in. If provided,
+                allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
+                respectively. If KeyEncoding is not specified, then PKCS#1 will be
+                used by default.
+              enum:
+              - pkcs1
+              - pkcs8
+              type: string
+            keySize:
+              description: KeySize is the key bit size of the corresponding private
+                key for this certificate. If provided, value must be between 2048
+                and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                to "ecdsa".
+              type: integer
+            organization:
+              description: Organization is the organization to be used on the Certificate
+              items:
+                type: string
+              type: array
+            renewBefore:
+              description: Certificate renew before expiration duration
+              type: string
+            secretName:
+              description: SecretName is the name of the secret resource to store
+                this secret in
+              type: string
+            usages:
+              description: Usages is the set of x509 actions that are enabled for
+                a given key. Defaults are ('digital signature', 'key encipherment')
+                if empty
+              items:
+                description: 'KeyUsage specifies valid usage contexts for keys. See:
+                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12'
+                enum:
+                - signing
+                - digital signature
+                - content commitment
+                - key encipherment
+                - key agreement
+                - data encipherment
+                - cert sign
+                - crl sign
+                - encipher only
+                - decipher only
+                - any
+                - server auth
+                - client auth
+                - code signing
+                - email protection
+                - s/mime
+                - ipsec end system
+                - ipsec tunnel
+                - ipsec user
+                - timestamping
+                - ocsp signing
+                - microsoft sgc
+                - netscape sgc
+                type: string
+              type: array
+          required:
+          - issuerRef
+          - secretName
+          type: object
+        status:
+          description: CertificateStatus defines the observed state of Certificate
+          properties:
+            conditions:
+              items:
+                description: CertificateCondition contains condition information for
+                  an Certificate.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            lastFailureTime:
+              format: date-time
+              type: string
+            notAfter:
+              description: The expiration time of the certificate stored in the secret
+                named by this resource in spec.secretName.
+              format: date-time
+              type: string
+          type: object
+      type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.6.0/clusterissuer-crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.6.0/clusterissuer-crd.yaml
@@ -1,0 +1,1981 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: clusterissuers.certmanager.k8s.io
+  labels:
+    app.kubernetes.io/instance: ibm-cert-manager-operator
+    app.kubernetes.io/managed-by: ibm-cert-manager-operator
+    app.kubernetes.io/name: cert-manager
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: ClusterIssuer
+    plural: clusterissuers
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IssuerSpec is the specification of an Issuer. This includes
+            any configuration required for the issuer.
+          properties:
+            acme:
+              description: ACMEIssuer contains the specification for an ACME issuer
+              properties:
+                dns01:
+                  description: 'DEPRECATED: DNS-01 config'
+                  properties:
+                    providers:
+                      items:
+                        description: ACMEIssuerDNS01Provider contains configuration
+                          for a DNS provider that can be used to solve ACME DNS01
+                          challenges.
+                        properties:
+                          acmedns:
+                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                              containing the configuration for ACME-DNS servers
+                            properties:
+                              accountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              host:
+                                type: string
+                            required:
+                            - accountSecretRef
+                            - host
+                            type: object
+                          akamai:
+                            description: ACMEIssuerDNS01ProviderAkamai is a structure
+                              containing the DNS configuration for Akamai DNS—Zone
+                              Record Management API
+                            properties:
+                              accessTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              serviceConsumerDomain:
+                                type: string
+                            required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                            type: object
+                          azuredns:
+                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                              containing the configuration for Azure DNS
+                            properties:
+                              clientID:
+                                type: string
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                                type: string
+                              hostedZoneName:
+                                type: string
+                              resourceGroupName:
+                                type: string
+                              subscriptionID:
+                                type: string
+                              tenantID:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecretSecretRef
+                            - resourceGroupName
+                            - subscriptionID
+                            - tenantID
+                            type: object
+                          clouddns:
+                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                              containing the DNS configuration for Google Cloud DNS
+                            properties:
+                              project:
+                                type: string
+                              serviceAccountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - project
+                            - serviceAccountSecretRef
+                            type: object
+                          cloudflare:
+                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                              containing the DNS configuration for Cloudflare
+                            properties:
+                              apiKeySecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              email:
+                                type: string
+                            required:
+                            - apiKeySecretRef
+                            - email
+                            type: object
+                          cnameStrategy:
+                            description: CNAMEStrategy configures how the DNS01 provider
+                              should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
+                            type: string
+                          digitalocean:
+                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                              structure containing the DNS configuration for DigitalOcean
+                              Domains
+                            properties:
+                              tokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - tokenSecretRef
+                            type: object
+                          name:
+                            description: Name is the name of the DNS provider, which
+                              should be used to reference this DNS provider configuration
+                              on Certificate resources.
+                            type: string
+                          rfc2136:
+                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                              containing the configuration for RFC2136 DNS
+                            properties:
+                              nameserver:
+                                description: 'The IP address of the DNS supporting
+                                  RFC2136. Required. Note: FQDN is not a valid value,
+                                  only IP.'
+                                type: string
+                              tsigAlgorithm:
+                                description: 'The TSIG Algorithm configured in the
+                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                  and ``tsigKeyName`` are defined. Supported values
+                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                  ``HMACSHA256`` or ``HMACSHA512``.'
+                                type: string
+                              tsigKeyName:
+                                description: The TSIG Key name configured in the DNS.
+                                  If ``tsigSecretSecretRef`` is defined, this field
+                                  is required.
+                                type: string
+                              tsigSecretSecretRef:
+                                description: The name of the secret containing the
+                                  TSIG value. If ``tsigKeyName`` is defined, this
+                                  field is required.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - nameserver
+                            type: object
+                          route53:
+                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                              containing the Route 53 configuration for AWS
+                            properties:
+                              accessKeyID:
+                                description: 'The AccessKeyID is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                type: string
+                              hostedZoneID:
+                                description: If set, the provider will manage only
+                                  this zone in Route53 and will not do an lookup using
+                                  the route53:ListHostedZonesByName api call.
+                                type: string
+                              region:
+                                description: Always set the region when using AccessKeyID
+                                  and SecretAccessKey
+                                type: string
+                              role:
+                                description: Role is a Role ARN which the Route53
+                                  provider will assume using either the explicit credentials
+                                  AccessKeyID/SecretAccessKey or the inferred credentials
+                                  from environment variables, shared credentials file
+                                  or AWS Instance metadata
+                                type: string
+                              secretAccessKeySecretRef:
+                                description: The SecretAccessKey is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - region
+                            type: object
+                          webhook:
+                            description: ACMEIssuerDNS01ProviderWebhook specifies
+                              configuration for a webhook DNS01 provider, including
+                              where to POST ChallengePayload resources.
+                            properties:
+                              config:
+                                description: Additional configuration that should
+                                  be passed to the webhook apiserver when challenges
+                                  are processed. This can contain arbitrary JSON data.
+                                  Secret values should not be specified in this stanza.
+                                  If secret values are needed (e.g. credentials for
+                                  a DNS service), you should use a SecretKeySelector
+                                  to reference a Secret resource. For details on the
+                                  schema of this field, consult the webhook provider
+                                  implementation's documentation.
+                                type: object
+                              groupName:
+                                description: The API group name that should be used
+                                  when POSTing ChallengePayload resources to the webhook
+                                  apiserver. This should be the same as the GroupName
+                                  specified in the webhook provider implementation.
+                                type: string
+                              solverName:
+                                description: The name of the solver to use, as defined
+                                  in the webhook provider implementation. This will
+                                  typically be the name of the provider, e.g. 'cloudflare'.
+                                type: string
+                            required:
+                            - groupName
+                            - solverName
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                  type: object
+                email:
+                  description: Email is the email for this account
+                  type: string
+                http01:
+                  description: 'DEPRECATED: HTTP-01 config'
+                  properties:
+                    serviceType:
+                      description: Optional service type for Kubernetes solver service
+                      type: string
+                  type: object
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  properties:
+                    key:
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  required:
+                  - name
+                  type: object
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+                solvers:
+                  description: Solvers is a list of challenge solvers that will be
+                    used to solve ACME challenges for the matching domains.
+                  items:
+                    properties:
+                      dns01:
+                        properties:
+                          acmedns:
+                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                              containing the configuration for ACME-DNS servers
+                            properties:
+                              accountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              host:
+                                type: string
+                            required:
+                            - accountSecretRef
+                            - host
+                            type: object
+                          akamai:
+                            description: ACMEIssuerDNS01ProviderAkamai is a structure
+                              containing the DNS configuration for Akamai DNS—Zone
+                              Record Management API
+                            properties:
+                              accessTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              serviceConsumerDomain:
+                                type: string
+                            required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                            type: object
+                          azuredns:
+                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                              containing the configuration for Azure DNS
+                            properties:
+                              clientID:
+                                type: string
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                                type: string
+                              hostedZoneName:
+                                type: string
+                              resourceGroupName:
+                                type: string
+                              subscriptionID:
+                                type: string
+                              tenantID:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecretSecretRef
+                            - resourceGroupName
+                            - subscriptionID
+                            - tenantID
+                            type: object
+                          clouddns:
+                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                              containing the DNS configuration for Google Cloud DNS
+                            properties:
+                              project:
+                                type: string
+                              serviceAccountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - project
+                            - serviceAccountSecretRef
+                            type: object
+                          cloudflare:
+                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                              containing the DNS configuration for Cloudflare
+                            properties:
+                              apiKeySecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              email:
+                                type: string
+                            required:
+                            - apiKeySecretRef
+                            - email
+                            type: object
+                          cnameStrategy:
+                            description: CNAMEStrategy configures how the DNS01 provider
+                              should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
+                            type: string
+                          digitalocean:
+                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                              structure containing the DNS configuration for DigitalOcean
+                              Domains
+                            properties:
+                              tokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - tokenSecretRef
+                            type: object
+                          rfc2136:
+                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                              containing the configuration for RFC2136 DNS
+                            properties:
+                              nameserver:
+                                description: 'The IP address of the DNS supporting
+                                  RFC2136. Required. Note: FQDN is not a valid value,
+                                  only IP.'
+                                type: string
+                              tsigAlgorithm:
+                                description: 'The TSIG Algorithm configured in the
+                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                  and ``tsigKeyName`` are defined. Supported values
+                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                  ``HMACSHA256`` or ``HMACSHA512``.'
+                                type: string
+                              tsigKeyName:
+                                description: The TSIG Key name configured in the DNS.
+                                  If ``tsigSecretSecretRef`` is defined, this field
+                                  is required.
+                                type: string
+                              tsigSecretSecretRef:
+                                description: The name of the secret containing the
+                                  TSIG value. If ``tsigKeyName`` is defined, this
+                                  field is required.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - nameserver
+                            type: object
+                          route53:
+                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                              containing the Route 53 configuration for AWS
+                            properties:
+                              accessKeyID:
+                                description: 'The AccessKeyID is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                type: string
+                              hostedZoneID:
+                                description: If set, the provider will manage only
+                                  this zone in Route53 and will not do an lookup using
+                                  the route53:ListHostedZonesByName api call.
+                                type: string
+                              region:
+                                description: Always set the region when using AccessKeyID
+                                  and SecretAccessKey
+                                type: string
+                              role:
+                                description: Role is a Role ARN which the Route53
+                                  provider will assume using either the explicit credentials
+                                  AccessKeyID/SecretAccessKey or the inferred credentials
+                                  from environment variables, shared credentials file
+                                  or AWS Instance metadata
+                                type: string
+                              secretAccessKeySecretRef:
+                                description: The SecretAccessKey is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - region
+                            type: object
+                          webhook:
+                            description: ACMEIssuerDNS01ProviderWebhook specifies
+                              configuration for a webhook DNS01 provider, including
+                              where to POST ChallengePayload resources.
+                            properties:
+                              config:
+                                description: Additional configuration that should
+                                  be passed to the webhook apiserver when challenges
+                                  are processed. This can contain arbitrary JSON data.
+                                  Secret values should not be specified in this stanza.
+                                  If secret values are needed (e.g. credentials for
+                                  a DNS service), you should use a SecretKeySelector
+                                  to reference a Secret resource. For details on the
+                                  schema of this field, consult the webhook provider
+                                  implementation's documentation.
+                                type: object
+                              groupName:
+                                description: The API group name that should be used
+                                  when POSTing ChallengePayload resources to the webhook
+                                  apiserver. This should be the same as the GroupName
+                                  specified in the webhook provider implementation.
+                                type: string
+                              solverName:
+                                description: The name of the solver to use, as defined
+                                  in the webhook provider implementation. This will
+                                  typically be the name of the provider, e.g. 'cloudflare'.
+                                type: string
+                            required:
+                            - groupName
+                            - solverName
+                            type: object
+                        type: object
+                      http01:
+                        description: ACMEChallengeSolverHTTP01 contains configuration
+                          detailing how to solve HTTP01 challenges within a Kubernetes
+                          cluster. Typically this is accomplished through creating
+                          'routes' of some description that configure ingress controllers
+                          to direct traffic to 'solver pods', which are responsible
+                          for responding to the ACME server's HTTP requests.
+                        properties:
+                          ingress:
+                            description: The ingress based HTTP01 challenge solver
+                              will solve challenges by creating or modifying Ingress
+                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                              to 'challenge solver' pods that are provisioned by cert-manager
+                              for each Challenge to be completed.
+                            properties:
+                              class:
+                                description: The ingress class to use when creating
+                                  Ingress resources to solve ACME challenges that
+                                  use this challenge solver. Only one of 'class' or
+                                  'name' may be specified.
+                                type: string
+                              name:
+                                description: The name of the ingress resource that
+                                  should have ACME challenge solving routes inserted
+                                  into it in order to solve HTTP01 challenges. This
+                                  is typically used in conjunction with ingress controllers
+                                  like ingress-gce, which maintains a 1:1 mapping
+                                  between external IPs and ingress resources.
+                                type: string
+                              podTemplate:
+                                description: Optional pod template used to configure
+                                  the ACME challenge solver pods used for HTTP01 challenges
+                                properties:
+                                  metadata:
+                                    description: ObjectMeta overrides for the pod
+                                      used to solve HTTP01 challenges. Only the 'labels'
+                                      and 'annotations' fields may be set. If labels
+                                      or annotations overlap with in-built values,
+                                      the values here will override the in-built values.
+                                    type: object
+                                  spec:
+                                    description: PodSpec defines overrides for the
+                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                      'affinity' and 'tolerations' fields are supported
+                                      currently. All other fields will be ignored.
+                                    properties:
+                                      affinity:
+                                        description: If specified, the pod's scheduling
+                                          constraints
+                                        properties:
+                                          nodeAffinity:
+                                            description: Describes node affinity scheduling
+                                              rules for the pod.
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node matches the
+                                                  corresponding matchExpressions;
+                                                  the node(s) with the highest sum
+                                                  are the most preferred.
+                                                items:
+                                                  description: An empty preferred
+                                                    scheduling term matches all objects
+                                                    with implicit weight 0 (i.e. it's
+                                                    a no-op). A null preferred scheduling
+                                                    term matches no objects (i.e.
+                                                    is also a no-op).
+                                                  properties:
+                                                    preference:
+                                                      description: A node selector
+                                                        term, associated with the
+                                                        corresponding weight.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    weight:
+                                                      description: Weight associated
+                                                        with matching the corresponding
+                                                        nodeSelectorTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to an update), the system
+                                                  may or may not try to eventually
+                                                  evict the pod from its node.
+                                                properties:
+                                                  nodeSelectorTerms:
+                                                    description: Required. A list
+                                                      of node selector terms. The
+                                                      terms are ORed.
+                                                    items:
+                                                      description: A null or empty
+                                                        node selector term matches
+                                                        no objects. The requirements
+                                                        of them are ANDed. The TopologySelectorTerm
+                                                        type implements a subset of
+                                                        the NodeSelectorTerm.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                required:
+                                                - nodeSelectorTerms
+                                                type: object
+                                            type: object
+                                          podAffinity:
+                                            description: Describes pod affinity scheduling
+                                              rules (e.g. co-locate this pod in the
+                                              same node, zone, etc. as some other
+                                              pod(s)).
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node has pods
+                                                  which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to a pod label update),
+                                                  the system may or may not try to
+                                                  eventually evict the pod from its
+                                                  node. When there are multiple elements,
+                                                  the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          podAntiAffinity:
+                                            description: Describes pod anti-affinity
+                                              scheduling rules (e.g. avoid putting
+                                              this pod in the same node, zone, etc.
+                                              as some other pod(s)).
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the anti-affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  anti-affinity expressions, etc.),
+                                                  compute a sum by iterating through
+                                                  the elements of this field and adding
+                                                  "weight" to the sum if the node
+                                                  has pods which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the anti-affinity
+                                                  requirements specified by this field
+                                                  are not met at scheduling time,
+                                                  the pod will not be scheduled onto
+                                                  the node. If the anti-affinity requirements
+                                                  specified by this field cease to
+                                                  be met at some point during pod
+                                                  execution (e.g. due to a pod label
+                                                  update), the system may or may not
+                                                  try to eventually evict the pod
+                                                  from its node. When there are multiple
+                                                  elements, the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                        type: object
+                                      nodeSelector:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'NodeSelector is a selector which
+                                          must be true for the pod to fit on a node.
+                                          Selector which must match a node''s labels
+                                          for the pod to be scheduled on that node.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                        type: object
+                                      tolerations:
+                                        description: If specified, the pod's tolerations.
+                                        items:
+                                          description: The pod this Toleration is
+                                            attached to tolerates any taint that matches
+                                            the triple <key,value,effect> using the
+                                            matching operator <operator>.
+                                          properties:
+                                            effect:
+                                              description: Effect indicates the taint
+                                                effect to match. Empty means match
+                                                all taint effects. When specified,
+                                                allowed values are NoSchedule, PreferNoSchedule
+                                                and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Key is the taint key that
+                                                the toleration applies to. Empty means
+                                                match all taint keys. If the key is
+                                                empty, operator must be Exists; this
+                                                combination means to match all values
+                                                and all keys.
+                                              type: string
+                                            operator:
+                                              description: Operator represents a key's
+                                                relationship to the value. Valid operators
+                                                are Exists and Equal. Defaults to
+                                                Equal. Exists is equivalent to wildcard
+                                                for value, so that a pod can tolerate
+                                                all taints of a particular category.
+                                              type: string
+                                            tolerationSeconds:
+                                              description: TolerationSeconds represents
+                                                the period of time the toleration
+                                                (which must be of effect NoExecute,
+                                                otherwise this field is ignored) tolerates
+                                                the taint. By default, it is not set,
+                                                which means tolerate the taint forever
+                                                (do not evict). Zero and negative
+                                                values will be treated as 0 (evict
+                                                immediately) by the system.
+                                              format: int64
+                                              type: integer
+                                            value:
+                                              description: Value is the taint value
+                                                the toleration matches to. If the
+                                                operator is Exists, the value should
+                                                be empty, otherwise just a regular
+                                                string.
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              serviceType:
+                                description: Optional service type for Kubernetes
+                                  solver service
+                                type: string
+                            type: object
+                        type: object
+                      selector:
+                        description: Selector selects a set of DNSNames on the Certificate
+                          resource that should be solved using this challenge solver.
+                        properties:
+                          dnsNames:
+                            description: List of DNSNames that this solver will be
+                              used to solve. If specified and a match is found, a
+                              dnsNames selector will take precedence over a dnsZones
+                              selector. If multiple solvers match with the same dnsNames
+                              value, the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          dnsZones:
+                            description: List of DNSZones that this solver will be
+                              used to solve. The most specific DNS zone match specified
+                              here will take precedence over other DNS zone matches,
+                              so a solver specifying sys.example.com will be selected
+                              over one specifying example.com for the domain www.sys.example.com.
+                              If multiple solvers match with the same dnsZones value,
+                              the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: A label selector that is used to refine the
+                              set of certificate's that this challenge solver will
+                              apply to.
+                            type: object
+                        type: object
+                    type: object
+                  type: array
+              required:
+              - privateKeySecretRef
+              - server
+              type: object
+            ca:
+              properties:
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+              required:
+              - secretName
+              type: object
+            selfSigned:
+              type: object
+            vault:
+              properties:
+                auth:
+                  description: Vault authentication
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+              required:
+              - auth
+              - path
+              - server
+              type: object
+            venafi:
+              description: VenafiIssuer describes issuer configuration details for
+                Venafi Cloud.
+              properties:
+                cloud:
+                  description: Cloud specifies the Venafi cloud configuration settings.
+                    Only one of TPP or Cloud may be specified.
+                  properties:
+                    apiTokenSecretRef:
+                      description: APITokenSecretRef is a secret key selector for
+                        the Venafi Cloud API token.
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for Venafi Cloud
+                      type: string
+                  required:
+                  - apiTokenSecretRef
+                  - url
+                  type: object
+                tpp:
+                  description: TPP specifies Trust Protection Platform configuration
+                    settings. Only one of TPP or Cloud may be specified.
+                  properties:
+                    caBundle:
+                      description: CABundle is a PEM encoded TLS certifiate to use
+                        to verify connections to the TPP instance. If specified, system
+                        roots will not be used and the issuing CA for the TPP instance
+                        must be verifiable using the provided root. If not specified,
+                        the connection will be verified using the cert-manager system
+                        root certificates.
+                      format: byte
+                      type: string
+                    credentialsRef:
+                      description: CredentialsRef is a reference to a Secret containing
+                        the username and password for the TPP server. The secret must
+                        contain two keys, 'username' and 'password'.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for the Venafi TPP instance
+                      type: string
+                  required:
+                  - credentialsRef
+                  - url
+                  type: object
+                zone:
+                  description: Zone is the Venafi Policy Zone to use for this issuer.
+                    All requests made to the Venafi platform will be restricted by
+                    the named zone policy. This field is required.
+                  type: string
+              required:
+              - zone
+              type: object
+          type: object
+        status:
+          description: IssuerStatus contains status information about an Issuer
+          properties:
+            acme:
+              properties:
+                lastRegisteredEmail:
+                  description: LastRegisteredEmail is the email associated with the
+                    latest registered ACME account, in order to track changes made
+                    to registered account associated with the  Issuer
+                  type: string
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+              type: object
+            conditions:
+              items:
+                description: IssuerCondition contains condition information for an
+                  Issuer.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.6.0/ibm-cert-manager-operator.v3.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.6.0/ibm-cert-manager-operator.v3.6.0.clusterserviceversion.yaml
@@ -1,0 +1,519 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "CertManager",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-cert-manager-operator",
+              "app.kubernetes.io/managed-by": "ibm-cert-manager-operator",
+              "app.kubernetes.io/name": "cert-manager"
+            },
+            "name": "default"
+          },
+          "spec": {
+            "enableWebhook": true,
+            "imageRegistry": "quay.io/opencloudio"
+          },
+          "status": {
+            "certManagerStatus": {}
+          }
+        },
+        {
+          "apiVersion": "certmanager.k8s.io/v1alpha1",
+          "kind": "Issuer",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-cert-manager-operator",
+              "app.kubernetes.io/managed-by": "ibm-cert-manager-operator",
+              "app.kubernetes.io/name": "cert-manager"
+            },
+            "name": "cs-ss-issuer",
+            "namespace": "ibm-common-services"
+          },
+          "spec": {
+            "selfSigned": {}
+          }
+        },
+        {
+          "apiVersion": "certmanager.k8s.io/v1alpha1",
+          "kind": "Certificate",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-cert-manager-operator",
+              "app.kubernetes.io/managed-by": "ibm-cert-manager-operator",
+              "app.kubernetes.io/name": "cert-manager"
+            },
+            "name": "cs-ca-certificate",
+            "namespace": "ibm-common-services"
+          },
+          "spec": {
+            "secretName": "cs-ca-certificate-secret",
+            "issuerRef": {
+              "name": "cs-ss-issuer",
+              "kind": "Issuer"
+            },
+            "commonName": "cs-ca-certificate",
+            "isCA": true
+          }
+        },
+        {
+          "apiVersion": "certmanager.k8s.io/v1alpha1",
+          "kind": "ClusterIssuer",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-cert-manager-operator",
+              "app.kubernetes.io/managed-by": "ibm-cert-manager-operator",
+              "app.kubernetes.io/name": "cert-manager"
+            },
+            "name": "cs-ca-clusterissuer"
+          },
+          "spec": {
+            "ca": {
+              "secretName": "cs-ca-certificate-secret"
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Security
+    certified: "false"
+    containerImage: quay.io/opencloudio/ibm-cert-manager-operator:latest
+    createdAt: "2020-04-10T10:16:16Z"
+    description: Operator for managing deployment of cert-manager service.
+    support: IBM
+  name: ibm-cert-manager-operator.v3.6.0
+  namespace: ibm-common-services
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents a certificate
+      displayName: Certificate
+      kind: Certificate
+      name: certificates.certmanager.k8s.io
+      version: v1alpha1
+    - description: Represents a cluster issuer
+      displayName: Cluster Issuer
+      kind: ClusterIssuer
+      name: clusterissuers.certmanager.k8s.io
+      version: v1alpha1
+    - description: Represents an issuer
+      displayName: Issuer
+      kind: Issuer
+      name: issuers.certmanager.k8s.io
+      version: v1alpha1
+    - description: CertManager is the Schema for the certmanagers API
+      kind: CertManager
+      name: certmanagers.operator.ibm.com
+      statusDescriptors:
+      - description: It will be as "OK when all objects are created successfully
+        displayName: CertManager Status
+        path: certManagerStatus
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+      version: v1alpha1
+      displayName: CertManager
+      resources:
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ClusterRole
+        name: clusterroles.rbac.authorization.k8s.io
+        version: v1
+      - kind: ClusterRoleBinding
+        name: clusterrolebindings.rbac.authorization.k8s.io
+        version: v1
+      - kind: CustomResourceDefinition
+        name: customresourcedefinitions.apiextensions.k8s.io
+        version: v1beta1
+      - kind: ServiceAccount
+        name: ''
+        version: v1
+      - kind: ValidatingWebhookConfiguration
+        name: validatingwebhookconfigurations.admissionregistration.k8s.io
+        version: v1beta1
+      - kind: MutatingWebhookConfiguration
+        name: mutatingwebhookconfigurations.admissionregistration.k8s.io
+        version: v1beta1
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: APIService
+        name: apiservices.apiregistration.k8s.io
+        version: v1
+      specDescriptors:
+      - description: Disables the use of hostNetwork by the webhook
+        displayName: DisableHostNetwork
+        path: disableHostNetwork
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: Enables the webhook component of cert-manager when set to true
+        displayName: EnableWebhook
+        path: enableWebhook
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: Appends the text to the image tag when it deploys cert-manager
+        displayName: ImagePostFix
+        path: imagePostFix
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: Sets the image registry to this when deploying cert-manager
+        displayName: ImageRegistry
+        path: imageRegistry
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The namespace where namespace scoped resources referenced by cert-manager clusterissuers must be placed
+        displayName: ResourceNamespace
+        path: resourceNamespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+  description: Operator for managing deployment of cert-manager service.
+  displayName: Ibm Cert Manager Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - operator.ibm.com
+          resources:
+          - certmanagers
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - namespaces
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - cert-manager-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - operator.ibm.com
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - certmanager.k8s.io
+          resources:
+          - certificates
+          - certificaterequests
+          - orders
+          - challenges
+          - clusterissuers
+          - issuers
+          verbs:
+          - '*'
+        - apiGroups:
+          - certmanager.k8s.io
+          resources:
+          - certificates/status
+          - certificaterequests/status
+          - challenges/status
+          - orders/status
+          - issuers/status
+          - clusterissuers/status
+          - certificates/finalizers
+          - challenges/finalizers
+          - ingresses/finalizers
+          - orders/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - statefulsets
+          - daemonsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - create
+          - update
+          - patch
+        - apiGroups:
+          - admission.certmanager.k8s.io
+          resources:
+          - certificates
+          - clusterissuers
+          - issuers
+          - certificaterequests
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - restricted
+          - hostnetwork
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - '*'
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - '*'
+        serviceAccountName: ibm-cert-manager-operator
+      deployments:
+      - name: ibm-cert-manager-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: ibm-cert-manager-operator
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                productName: IBM Cloud Platform Common Services
+                productID: 068a62892a1e4db39641342e592daa25
+                productVersion: 3.3.0
+                productMetric: FREE
+              labels:
+                app.kubernetes.io/instance: ibm-cert-manager-operator
+                app.kubernetes.io/managed-by: ibm-cert-manager-operator
+                app.kubernetes.io/name: cert-manager
+                name: ibm-cert-manager-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: beta.kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - ppc64le
+                        - s390x
+              containers:
+              - args:
+                - --zap-level=1
+                command:
+                - ibm-cert-manager-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: ibm-cert-manager-operator
+                image: quay.io/opencloudio/ibm-cert-manager-operator:latest
+                imagePullPolicy: Always
+                name: ibm-cert-manager-operator
+                resources:
+                  limits:
+                    cpu: 20m
+                    memory: 90Mi
+                  requests:
+                    cpu: 10m
+                    memory: 50Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: true
+              serviceAccountName: ibm-cert-manager-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - Cert-Manager
+  - IBM
+  - Cloud
+  maintainers:
+  - email: swati.nair@ibm.com
+    name: Swati Shridhar Nair
+  - email: tthorpe@us.ibm.com
+    name: Robert T. Thorpe
+  maturity: alpha
+  provider:
+    name: IBM
+  replaces: ibm-cert-manager-operator.v3.5.0
+  version: 3.6.0

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.6.0/issuer-crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.6.0/issuer-crd.yaml
@@ -1,0 +1,1981 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: issuers.certmanager.k8s.io
+  labels:
+    app.kubernetes.io/instance: ibm-cert-manager-operator
+    app.kubernetes.io/managed-by: ibm-cert-manager-operator
+    app.kubernetes.io/name: cert-manager
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IssuerSpec is the specification of an Issuer. This includes
+            any configuration required for the issuer.
+          properties:
+            acme:
+              description: ACMEIssuer contains the specification for an ACME issuer
+              properties:
+                dns01:
+                  description: 'DEPRECATED: DNS-01 config'
+                  properties:
+                    providers:
+                      items:
+                        description: ACMEIssuerDNS01Provider contains configuration
+                          for a DNS provider that can be used to solve ACME DNS01
+                          challenges.
+                        properties:
+                          acmedns:
+                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                              containing the configuration for ACME-DNS servers
+                            properties:
+                              accountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              host:
+                                type: string
+                            required:
+                            - accountSecretRef
+                            - host
+                            type: object
+                          akamai:
+                            description: ACMEIssuerDNS01ProviderAkamai is a structure
+                              containing the DNS configuration for Akamai DNS—Zone
+                              Record Management API
+                            properties:
+                              accessTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              serviceConsumerDomain:
+                                type: string
+                            required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                            type: object
+                          azuredns:
+                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                              containing the configuration for Azure DNS
+                            properties:
+                              clientID:
+                                type: string
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                                type: string
+                              hostedZoneName:
+                                type: string
+                              resourceGroupName:
+                                type: string
+                              subscriptionID:
+                                type: string
+                              tenantID:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecretSecretRef
+                            - resourceGroupName
+                            - subscriptionID
+                            - tenantID
+                            type: object
+                          clouddns:
+                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                              containing the DNS configuration for Google Cloud DNS
+                            properties:
+                              project:
+                                type: string
+                              serviceAccountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - project
+                            - serviceAccountSecretRef
+                            type: object
+                          cloudflare:
+                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                              containing the DNS configuration for Cloudflare
+                            properties:
+                              apiKeySecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              email:
+                                type: string
+                            required:
+                            - apiKeySecretRef
+                            - email
+                            type: object
+                          cnameStrategy:
+                            description: CNAMEStrategy configures how the DNS01 provider
+                              should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
+                            type: string
+                          digitalocean:
+                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                              structure containing the DNS configuration for DigitalOcean
+                              Domains
+                            properties:
+                              tokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - tokenSecretRef
+                            type: object
+                          name:
+                            description: Name is the name of the DNS provider, which
+                              should be used to reference this DNS provider configuration
+                              on Certificate resources.
+                            type: string
+                          rfc2136:
+                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                              containing the configuration for RFC2136 DNS
+                            properties:
+                              nameserver:
+                                description: 'The IP address of the DNS supporting
+                                  RFC2136. Required. Note: FQDN is not a valid value,
+                                  only IP.'
+                                type: string
+                              tsigAlgorithm:
+                                description: 'The TSIG Algorithm configured in the
+                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                  and ``tsigKeyName`` are defined. Supported values
+                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                  ``HMACSHA256`` or ``HMACSHA512``.'
+                                type: string
+                              tsigKeyName:
+                                description: The TSIG Key name configured in the DNS.
+                                  If ``tsigSecretSecretRef`` is defined, this field
+                                  is required.
+                                type: string
+                              tsigSecretSecretRef:
+                                description: The name of the secret containing the
+                                  TSIG value. If ``tsigKeyName`` is defined, this
+                                  field is required.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - nameserver
+                            type: object
+                          route53:
+                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                              containing the Route 53 configuration for AWS
+                            properties:
+                              accessKeyID:
+                                description: 'The AccessKeyID is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                type: string
+                              hostedZoneID:
+                                description: If set, the provider will manage only
+                                  this zone in Route53 and will not do an lookup using
+                                  the route53:ListHostedZonesByName api call.
+                                type: string
+                              region:
+                                description: Always set the region when using AccessKeyID
+                                  and SecretAccessKey
+                                type: string
+                              role:
+                                description: Role is a Role ARN which the Route53
+                                  provider will assume using either the explicit credentials
+                                  AccessKeyID/SecretAccessKey or the inferred credentials
+                                  from environment variables, shared credentials file
+                                  or AWS Instance metadata
+                                type: string
+                              secretAccessKeySecretRef:
+                                description: The SecretAccessKey is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - region
+                            type: object
+                          webhook:
+                            description: ACMEIssuerDNS01ProviderWebhook specifies
+                              configuration for a webhook DNS01 provider, including
+                              where to POST ChallengePayload resources.
+                            properties:
+                              config:
+                                description: Additional configuration that should
+                                  be passed to the webhook apiserver when challenges
+                                  are processed. This can contain arbitrary JSON data.
+                                  Secret values should not be specified in this stanza.
+                                  If secret values are needed (e.g. credentials for
+                                  a DNS service), you should use a SecretKeySelector
+                                  to reference a Secret resource. For details on the
+                                  schema of this field, consult the webhook provider
+                                  implementation's documentation.
+                                type: object
+                              groupName:
+                                description: The API group name that should be used
+                                  when POSTing ChallengePayload resources to the webhook
+                                  apiserver. This should be the same as the GroupName
+                                  specified in the webhook provider implementation.
+                                type: string
+                              solverName:
+                                description: The name of the solver to use, as defined
+                                  in the webhook provider implementation. This will
+                                  typically be the name of the provider, e.g. 'cloudflare'.
+                                type: string
+                            required:
+                            - groupName
+                            - solverName
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                  type: object
+                email:
+                  description: Email is the email for this account
+                  type: string
+                http01:
+                  description: 'DEPRECATED: HTTP-01 config'
+                  properties:
+                    serviceType:
+                      description: Optional service type for Kubernetes solver service
+                      type: string
+                  type: object
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  properties:
+                    key:
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  required:
+                  - name
+                  type: object
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+                solvers:
+                  description: Solvers is a list of challenge solvers that will be
+                    used to solve ACME challenges for the matching domains.
+                  items:
+                    properties:
+                      dns01:
+                        properties:
+                          acmedns:
+                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                              containing the configuration for ACME-DNS servers
+                            properties:
+                              accountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              host:
+                                type: string
+                            required:
+                            - accountSecretRef
+                            - host
+                            type: object
+                          akamai:
+                            description: ACMEIssuerDNS01ProviderAkamai is a structure
+                              containing the DNS configuration for Akamai DNS—Zone
+                              Record Management API
+                            properties:
+                              accessTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              serviceConsumerDomain:
+                                type: string
+                            required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                            type: object
+                          azuredns:
+                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                              containing the configuration for Azure DNS
+                            properties:
+                              clientID:
+                                type: string
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                                type: string
+                              hostedZoneName:
+                                type: string
+                              resourceGroupName:
+                                type: string
+                              subscriptionID:
+                                type: string
+                              tenantID:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecretSecretRef
+                            - resourceGroupName
+                            - subscriptionID
+                            - tenantID
+                            type: object
+                          clouddns:
+                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                              containing the DNS configuration for Google Cloud DNS
+                            properties:
+                              project:
+                                type: string
+                              serviceAccountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - project
+                            - serviceAccountSecretRef
+                            type: object
+                          cloudflare:
+                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                              containing the DNS configuration for Cloudflare
+                            properties:
+                              apiKeySecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              email:
+                                type: string
+                            required:
+                            - apiKeySecretRef
+                            - email
+                            type: object
+                          cnameStrategy:
+                            description: CNAMEStrategy configures how the DNS01 provider
+                              should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
+                            type: string
+                          digitalocean:
+                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                              structure containing the DNS configuration for DigitalOcean
+                              Domains
+                            properties:
+                              tokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - tokenSecretRef
+                            type: object
+                          rfc2136:
+                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                              containing the configuration for RFC2136 DNS
+                            properties:
+                              nameserver:
+                                description: 'The IP address of the DNS supporting
+                                  RFC2136. Required. Note: FQDN is not a valid value,
+                                  only IP.'
+                                type: string
+                              tsigAlgorithm:
+                                description: 'The TSIG Algorithm configured in the
+                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                  and ``tsigKeyName`` are defined. Supported values
+                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                  ``HMACSHA256`` or ``HMACSHA512``.'
+                                type: string
+                              tsigKeyName:
+                                description: The TSIG Key name configured in the DNS.
+                                  If ``tsigSecretSecretRef`` is defined, this field
+                                  is required.
+                                type: string
+                              tsigSecretSecretRef:
+                                description: The name of the secret containing the
+                                  TSIG value. If ``tsigKeyName`` is defined, this
+                                  field is required.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - nameserver
+                            type: object
+                          route53:
+                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                              containing the Route 53 configuration for AWS
+                            properties:
+                              accessKeyID:
+                                description: 'The AccessKeyID is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                type: string
+                              hostedZoneID:
+                                description: If set, the provider will manage only
+                                  this zone in Route53 and will not do an lookup using
+                                  the route53:ListHostedZonesByName api call.
+                                type: string
+                              region:
+                                description: Always set the region when using AccessKeyID
+                                  and SecretAccessKey
+                                type: string
+                              role:
+                                description: Role is a Role ARN which the Route53
+                                  provider will assume using either the explicit credentials
+                                  AccessKeyID/SecretAccessKey or the inferred credentials
+                                  from environment variables, shared credentials file
+                                  or AWS Instance metadata
+                                type: string
+                              secretAccessKeySecretRef:
+                                description: The SecretAccessKey is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - region
+                            type: object
+                          webhook:
+                            description: ACMEIssuerDNS01ProviderWebhook specifies
+                              configuration for a webhook DNS01 provider, including
+                              where to POST ChallengePayload resources.
+                            properties:
+                              config:
+                                description: Additional configuration that should
+                                  be passed to the webhook apiserver when challenges
+                                  are processed. This can contain arbitrary JSON data.
+                                  Secret values should not be specified in this stanza.
+                                  If secret values are needed (e.g. credentials for
+                                  a DNS service), you should use a SecretKeySelector
+                                  to reference a Secret resource. For details on the
+                                  schema of this field, consult the webhook provider
+                                  implementation's documentation.
+                                type: object
+                              groupName:
+                                description: The API group name that should be used
+                                  when POSTing ChallengePayload resources to the webhook
+                                  apiserver. This should be the same as the GroupName
+                                  specified in the webhook provider implementation.
+                                type: string
+                              solverName:
+                                description: The name of the solver to use, as defined
+                                  in the webhook provider implementation. This will
+                                  typically be the name of the provider, e.g. 'cloudflare'.
+                                type: string
+                            required:
+                            - groupName
+                            - solverName
+                            type: object
+                        type: object
+                      http01:
+                        description: ACMEChallengeSolverHTTP01 contains configuration
+                          detailing how to solve HTTP01 challenges within a Kubernetes
+                          cluster. Typically this is accomplished through creating
+                          'routes' of some description that configure ingress controllers
+                          to direct traffic to 'solver pods', which are responsible
+                          for responding to the ACME server's HTTP requests.
+                        properties:
+                          ingress:
+                            description: The ingress based HTTP01 challenge solver
+                              will solve challenges by creating or modifying Ingress
+                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                              to 'challenge solver' pods that are provisioned by cert-manager
+                              for each Challenge to be completed.
+                            properties:
+                              class:
+                                description: The ingress class to use when creating
+                                  Ingress resources to solve ACME challenges that
+                                  use this challenge solver. Only one of 'class' or
+                                  'name' may be specified.
+                                type: string
+                              name:
+                                description: The name of the ingress resource that
+                                  should have ACME challenge solving routes inserted
+                                  into it in order to solve HTTP01 challenges. This
+                                  is typically used in conjunction with ingress controllers
+                                  like ingress-gce, which maintains a 1:1 mapping
+                                  between external IPs and ingress resources.
+                                type: string
+                              podTemplate:
+                                description: Optional pod template used to configure
+                                  the ACME challenge solver pods used for HTTP01 challenges
+                                properties:
+                                  metadata:
+                                    description: ObjectMeta overrides for the pod
+                                      used to solve HTTP01 challenges. Only the 'labels'
+                                      and 'annotations' fields may be set. If labels
+                                      or annotations overlap with in-built values,
+                                      the values here will override the in-built values.
+                                    type: object
+                                  spec:
+                                    description: PodSpec defines overrides for the
+                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                      'affinity' and 'tolerations' fields are supported
+                                      currently. All other fields will be ignored.
+                                    properties:
+                                      affinity:
+                                        description: If specified, the pod's scheduling
+                                          constraints
+                                        properties:
+                                          nodeAffinity:
+                                            description: Describes node affinity scheduling
+                                              rules for the pod.
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node matches the
+                                                  corresponding matchExpressions;
+                                                  the node(s) with the highest sum
+                                                  are the most preferred.
+                                                items:
+                                                  description: An empty preferred
+                                                    scheduling term matches all objects
+                                                    with implicit weight 0 (i.e. it's
+                                                    a no-op). A null preferred scheduling
+                                                    term matches no objects (i.e.
+                                                    is also a no-op).
+                                                  properties:
+                                                    preference:
+                                                      description: A node selector
+                                                        term, associated with the
+                                                        corresponding weight.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    weight:
+                                                      description: Weight associated
+                                                        with matching the corresponding
+                                                        nodeSelectorTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to an update), the system
+                                                  may or may not try to eventually
+                                                  evict the pod from its node.
+                                                properties:
+                                                  nodeSelectorTerms:
+                                                    description: Required. A list
+                                                      of node selector terms. The
+                                                      terms are ORed.
+                                                    items:
+                                                      description: A null or empty
+                                                        node selector term matches
+                                                        no objects. The requirements
+                                                        of them are ANDed. The TopologySelectorTerm
+                                                        type implements a subset of
+                                                        the NodeSelectorTerm.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                required:
+                                                - nodeSelectorTerms
+                                                type: object
+                                            type: object
+                                          podAffinity:
+                                            description: Describes pod affinity scheduling
+                                              rules (e.g. co-locate this pod in the
+                                              same node, zone, etc. as some other
+                                              pod(s)).
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node has pods
+                                                  which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to a pod label update),
+                                                  the system may or may not try to
+                                                  eventually evict the pod from its
+                                                  node. When there are multiple elements,
+                                                  the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          podAntiAffinity:
+                                            description: Describes pod anti-affinity
+                                              scheduling rules (e.g. avoid putting
+                                              this pod in the same node, zone, etc.
+                                              as some other pod(s)).
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the anti-affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  anti-affinity expressions, etc.),
+                                                  compute a sum by iterating through
+                                                  the elements of this field and adding
+                                                  "weight" to the sum if the node
+                                                  has pods which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the anti-affinity
+                                                  requirements specified by this field
+                                                  are not met at scheduling time,
+                                                  the pod will not be scheduled onto
+                                                  the node. If the anti-affinity requirements
+                                                  specified by this field cease to
+                                                  be met at some point during pod
+                                                  execution (e.g. due to a pod label
+                                                  update), the system may or may not
+                                                  try to eventually evict the pod
+                                                  from its node. When there are multiple
+                                                  elements, the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                        type: object
+                                      nodeSelector:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'NodeSelector is a selector which
+                                          must be true for the pod to fit on a node.
+                                          Selector which must match a node''s labels
+                                          for the pod to be scheduled on that node.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                        type: object
+                                      tolerations:
+                                        description: If specified, the pod's tolerations.
+                                        items:
+                                          description: The pod this Toleration is
+                                            attached to tolerates any taint that matches
+                                            the triple <key,value,effect> using the
+                                            matching operator <operator>.
+                                          properties:
+                                            effect:
+                                              description: Effect indicates the taint
+                                                effect to match. Empty means match
+                                                all taint effects. When specified,
+                                                allowed values are NoSchedule, PreferNoSchedule
+                                                and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Key is the taint key that
+                                                the toleration applies to. Empty means
+                                                match all taint keys. If the key is
+                                                empty, operator must be Exists; this
+                                                combination means to match all values
+                                                and all keys.
+                                              type: string
+                                            operator:
+                                              description: Operator represents a key's
+                                                relationship to the value. Valid operators
+                                                are Exists and Equal. Defaults to
+                                                Equal. Exists is equivalent to wildcard
+                                                for value, so that a pod can tolerate
+                                                all taints of a particular category.
+                                              type: string
+                                            tolerationSeconds:
+                                              description: TolerationSeconds represents
+                                                the period of time the toleration
+                                                (which must be of effect NoExecute,
+                                                otherwise this field is ignored) tolerates
+                                                the taint. By default, it is not set,
+                                                which means tolerate the taint forever
+                                                (do not evict). Zero and negative
+                                                values will be treated as 0 (evict
+                                                immediately) by the system.
+                                              format: int64
+                                              type: integer
+                                            value:
+                                              description: Value is the taint value
+                                                the toleration matches to. If the
+                                                operator is Exists, the value should
+                                                be empty, otherwise just a regular
+                                                string.
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              serviceType:
+                                description: Optional service type for Kubernetes
+                                  solver service
+                                type: string
+                            type: object
+                        type: object
+                      selector:
+                        description: Selector selects a set of DNSNames on the Certificate
+                          resource that should be solved using this challenge solver.
+                        properties:
+                          dnsNames:
+                            description: List of DNSNames that this solver will be
+                              used to solve. If specified and a match is found, a
+                              dnsNames selector will take precedence over a dnsZones
+                              selector. If multiple solvers match with the same dnsNames
+                              value, the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          dnsZones:
+                            description: List of DNSZones that this solver will be
+                              used to solve. The most specific DNS zone match specified
+                              here will take precedence over other DNS zone matches,
+                              so a solver specifying sys.example.com will be selected
+                              over one specifying example.com for the domain www.sys.example.com.
+                              If multiple solvers match with the same dnsZones value,
+                              the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: A label selector that is used to refine the
+                              set of certificate's that this challenge solver will
+                              apply to.
+                            type: object
+                        type: object
+                    type: object
+                  type: array
+              required:
+              - privateKeySecretRef
+              - server
+              type: object
+            ca:
+              properties:
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+              required:
+              - secretName
+              type: object
+            selfSigned:
+              type: object
+            vault:
+              properties:
+                auth:
+                  description: Vault authentication
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+              required:
+              - auth
+              - path
+              - server
+              type: object
+            venafi:
+              description: VenafiIssuer describes issuer configuration details for
+                Venafi Cloud.
+              properties:
+                cloud:
+                  description: Cloud specifies the Venafi cloud configuration settings.
+                    Only one of TPP or Cloud may be specified.
+                  properties:
+                    apiTokenSecretRef:
+                      description: APITokenSecretRef is a secret key selector for
+                        the Venafi Cloud API token.
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for Venafi Cloud
+                      type: string
+                  required:
+                  - apiTokenSecretRef
+                  - url
+                  type: object
+                tpp:
+                  description: TPP specifies Trust Protection Platform configuration
+                    settings. Only one of TPP or Cloud may be specified.
+                  properties:
+                    caBundle:
+                      description: CABundle is a PEM encoded TLS certifiate to use
+                        to verify connections to the TPP instance. If specified, system
+                        roots will not be used and the issuing CA for the TPP instance
+                        must be verifiable using the provided root. If not specified,
+                        the connection will be verified using the cert-manager system
+                        root certificates.
+                      format: byte
+                      type: string
+                    credentialsRef:
+                      description: CredentialsRef is a reference to a Secret containing
+                        the username and password for the TPP server. The secret must
+                        contain two keys, 'username' and 'password'.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for the Venafi TPP instance
+                      type: string
+                  required:
+                  - credentialsRef
+                  - url
+                  type: object
+                zone:
+                  description: Zone is the Venafi Policy Zone to use for this issuer.
+                    All requests made to the Venafi platform will be restricted by
+                    the named zone policy. This field is required.
+                  type: string
+              required:
+              - zone
+              type: object
+          type: object
+        status:
+          description: IssuerStatus contains status information about an Issuer
+          properties:
+            acme:
+              properties:
+                lastRegisteredEmail:
+                  description: LastRegisteredEmail is the email associated with the
+                    latest registered ACME account, in order to track changes made
+                    to registered account associated with the  Issuer
+                  type: string
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+              type: object
+            conditions:
+              items:
+                description: IssuerCondition contains condition information for an
+                  Issuer.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.6.0/operator.ibm.com_certmanagers_crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.6.0/operator.ibm.com_certmanagers_crd.yaml
@@ -1,0 +1,67 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certmanagers.operator.ibm.com
+  labels:
+    app.kubernetes.io/instance: ibm-cert-manager-operator
+    app.kubernetes.io/managed-by: ibm-cert-manager-operator
+    app.kubernetes.io/name: cert-manager
+spec:
+  group: operator.ibm.com
+  names:
+    kind: CertManager
+    listKind: CertManagerList
+    plural: certmanagers
+    singular: certmanager
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: CertManager is the Schema for the certmanagers API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CertManagerSpec defines the desired state of CertManager
+          properties:
+            disableHostNetwork:
+              type: boolean
+            enableWebhook:
+              type: boolean
+            imagePostFix:
+              type: string
+            imageRegistry:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              type: string
+            resourceNamespace:
+              type: string
+          type: object
+        status:
+          description: CertManagerStatus defines the observed state of CertManager
+          properties:
+            certManagerStatus:
+              description: It will be as "OK when all objects are created successfully
+              type: string
+          required:
+          - certManagerStatus
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ibm-cert-manager-operator/ibm-cert-manager-operator.package.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/ibm-cert-manager-operator.package.yaml
@@ -1,4 +1,6 @@
 channels:
+- currentCSV: ibm-cert-manager-operator.v3.6.0
+  name: dev
 - currentCSV: ibm-cert-manager-operator.v3.5.0
   name: stable-v1
 defaultChannel: stable-v1

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -38,7 +38,7 @@ spec:
                 - s390x
       containers:
         - name: ibm-cert-manager-operator
-          image: quay.io/opencloudio/ibm-cert-manager-operator:3.5.0
+          image: quay.io/opencloudio/ibm-cert-manager-operator:latest
           command:
           - ibm-cert-manager-operator
           args:

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 var (
-	Version = "3.5.0"
+	Version = "3.6.0"
 )


### PR DESCRIPTION
1. Generated CSV for 3.6.0
2. Updated CSV manually with necessary fields after comparing it with 3.5.0
3. Makefile: Added install and uninstall targets to test the CSV locally through the command line
4. Tested the changes locally on test cluster by deploying the 3.6.0 CSV