### PR TITLE
Fix certManagerStatus initialization in certmanager CR

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml
@@ -10,4 +10,4 @@ spec:
   enableWebhook: true
   imageRegistry: quay.io/opencloudio
 status:
-  certManagerStatus: {}
+  certManagerStatus: ''

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.6.0/ibm-cert-manager-operator.v3.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.6.0/ibm-cert-manager-operator.v3.6.0.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
             "imageRegistry": "quay.io/opencloudio"
           },
           "status": {
-            "certManagerStatus": {}
+            "certManagerStatus": ''
           }
         },
         {


### PR DESCRIPTION
Updated the certManagerStatus field in the CertManager CR to `''` from `{}` as it is of type string.