### PR TITLE
Update UBI images and operand SHA references

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:fc7fc7bc6b293fd2ec1c1b035acc6b97ba34f0700c5366b699c646d947c39f81
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:9ee638018440bf04525e4d2f07990f0cc9958f1ab04a4bd0284ac7f86aaeac45
 
 ENV OPERATOR=/usr/local/bin/ibm-cert-manager-operator \
     USER_UID=1001 \

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -4,7 +4,7 @@ RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/r
 
 RUN chmod +x /qemu-ppc64le-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:7e432c89f285392c7d09343a3100e97158121bd5f73b89c852eba9609e19f9f4
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:492093348fd31e34c1d7d7c23fbce3bb0199f8b0833488af44165ab1d4625bdb
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -4,7 +4,7 @@ RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/rel
 
 RUN chmod +x /qemu-s390x-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:7bb4dacb1e5fb5ad0742578d616982f836778fd0c5a0a00f843e9a7b1dabf487
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:8cdff755d0fa477f3b2c69cedcf78d89a9e2bf965f3d72ab804c2e39f3e58ab1
 ARG VCS_REF
 ARG VCS_URL
 

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.6.3/ibm-cert-manager-operator.v3.6.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.6.3/ibm-cert-manager-operator.v3.6.3.clusterserviceversion.yaml
@@ -493,13 +493,13 @@ spec:
                 - name: OPERATOR_NAME
                   value: ibm-cert-manager-operator
                 - name: CONTROLLER_IMAGE_TAG_OR_SHA
-                  value: sha256:8c8fcc26460f57169baeb928eba0dc5acc1394d44c339cc48585b32660693945
+                  value: sha256:cf12ad00d4e1a41136b57d28e1580cbeb4b3ee7decd3aef36996846cbdf82325
                 - name: WEBHOOK_IMAGE_TAG_OR_SHA
-                  value: sha256:c91b16124aa05992e4ad08276608e6956ee4a471bd7c63f5d3bb7b6270a24d78
+                  value: sha256:c0fc6219d4e4f04af4a2d2e9966e584a23cce3fa127ad42680d9a7da45a4be1b
                 - name: CAINJECTOR_IMAGE_TAG_OR_SHA
-                  value: sha256:b67ef10f75d11bf487493a32ad95f605b7f3dea556174d0c143dc98abdcb2dc9
+                  value: sha256:8d1affe3688b13ddf2844c6f75e54bdb62fa2f3e3be135a4caf7c3b886dc9ab3
                 - name: ACMESOLVER_IMAGE_TAG_OR_SHA
-                  value: sha256:111018d72db71b43266709ba05c14acfd18855005dc6b9e36865d26853e88698
+                  value: sha256:98264fbdd2fe8bd5ebb9b17214b48e4c8c634051bf3fd2ed58170b4b0aaed0a6
                 - name: CONFIGMAP_WATCHER_IMAGE_TAG_OR_SHA
                   value: sha256:6f6bd9ae19b9f9ed8c013b889931c01a2fab9051b7ffe90161a089045ba3eaa9
                 image: quay.io/opencloudio/ibm-cert-manager-operator:latest

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -60,13 +60,13 @@ spec:
               value: "ibm-cert-manager-operator"
             # DO NOT DELETE. Add operand image SHAs here. See common/scripts/get_image_sha_digest.sh and make get-all-operand-image-sha
             - name: CONTROLLER_IMAGE_TAG_OR_SHA
-              value: sha256:8c8fcc26460f57169baeb928eba0dc5acc1394d44c339cc48585b32660693945
+              value: sha256:cf12ad00d4e1a41136b57d28e1580cbeb4b3ee7decd3aef36996846cbdf82325
             - name: WEBHOOK_IMAGE_TAG_OR_SHA
-              value: sha256:c91b16124aa05992e4ad08276608e6956ee4a471bd7c63f5d3bb7b6270a24d78
+              value: sha256:c0fc6219d4e4f04af4a2d2e9966e584a23cce3fa127ad42680d9a7da45a4be1b
             - name: CAINJECTOR_IMAGE_TAG_OR_SHA
-              value: sha256:b67ef10f75d11bf487493a32ad95f605b7f3dea556174d0c143dc98abdcb2dc9
+              value: sha256:8d1affe3688b13ddf2844c6f75e54bdb62fa2f3e3be135a4caf7c3b886dc9ab3
             - name: ACMESOLVER_IMAGE_TAG_OR_SHA
-              value: sha256:111018d72db71b43266709ba05c14acfd18855005dc6b9e36865d26853e88698
+              value: sha256:98264fbdd2fe8bd5ebb9b17214b48e4c8c634051bf3fd2ed58170b4b0aaed0a6
             - name: CONFIGMAP_WATCHER_IMAGE_TAG_OR_SHA
               value: sha256:6f6bd9ae19b9f9ed8c013b889931c01a2fab9051b7ffe90161a089045ba3eaa9
           resources:


### PR DESCRIPTION
- Update UBI images to remove scan vulnerabilities
- Update operand SHA references to refer the latest operand images in quay
- Deployed in test cluster successfully