### PR TITLE
Remove product version metering annotation

### DIFF
--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.7.0/ibm-cert-manager-operator.v3.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.7.0/ibm-cert-manager-operator.v3.7.0.clusterserviceversion.yaml
@@ -454,7 +454,6 @@ spec:
               annotations:
                 productName: IBM Cloud Platform Common Services
                 productID: 068a62892a1e4db39641342e592daa25
-                productVersion: "3.4.0"
                 productMetric: FREE
               labels:
                 app.kubernetes.io/instance: ibm-cert-manager-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -21,7 +21,6 @@ spec:
       annotations:
         productName: IBM Cloud Platform Common Services
         productID: "068a62892a1e4db39641342e592daa25"
-        productVersion: "3.4.0"
         productMetric: FREE
     spec:
       serviceAccountName: ibm-cert-manager-operator

--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -81,13 +81,12 @@ var ConfigmapWatcherLabelMap = map[string]string{
 }
 
 // PodAnnotations are the annotations required for a pod
-var PodAnnotations = map[string]string{"openshift.io/scc": "restricted", "productName": "IBM Cloud Platform Common Services", "productID": "068a62892a1e4db39641342e592daa25", "productVersion": "3.4.0", "productMetric": "FREE"}
+var PodAnnotations = map[string]string{"openshift.io/scc": "restricted", "productName": "IBM Cloud Platform Common Services", "productID": "068a62892a1e4db39641342e592daa25", "productMetric": "FREE"}
 
 var securityAnnotationWebhook = map[string]string{"openshift.io/scc": "hostnetwork",
-	"productName":    "IBM Cloud Platform Common Services",
-	"productID":      "068a62892a1e4db39641342e592daa25",
-	"productVersion": "3.4.0",
-	"productMetric":  "FREE",
+	"productName":   "IBM Cloud Platform Common Services",
+	"productID":     "068a62892a1e4db39641342e592daa25",
+	"productMetric": "FREE",
 }
 
 var webhookAnnotation = map[string]string{


### PR DESCRIPTION
As required by metering/licensing squad, removing productVersion annotation from the operator and operands altogether