### PR TITLE
update go version to 1.14 and update operand shas

### DIFF
--- a/common/scripts/get_image_sha_digest.sh
+++ b/common/scripts/get_image_sha_digest.sh
@@ -17,6 +17,17 @@
 # Get the SHA from the RepoDigests section of an operand image.
 # Do "docker login" before running this script.
 # Run this script from the parent dir by typing "scripts/get-image-sha.sh"
+# Do "docker login" before running this script.
+
+SED="sed"
+unamestr=$(uname)
+if [[ "$unamestr" == "Darwin" ]] ; then
+    SED=gsed
+    type $SED >/dev/null 2>&1 || {
+        echo >&2 "$SED it's not installed. Try: brew install gnu-sed" ;
+        exit 1;
+    }
+fi
 
 FILE=deploy/operator.yaml
 
@@ -27,7 +38,7 @@ TAG=$3
 TYPE=$4
 if [[ $TYPE == "" ]]
 then
-   echo "Missing parm. Need image registry, image name, image tag, and env variable indicating operand type. Tye will be OPERATOR for operator image as input"
+   echo "Missing parm. Need image registry, image name, image tag, and env variable indicating operand type. Type will be OPERATOR for operator image as input"
    echo "for eg: quay.io/opencloudio icp-cert-manager-controller x.y.z CONTROLLER_IMAGE_TAG_OR_SHA"
    exit 1
 fi
@@ -51,14 +62,27 @@ SHA=$DIGEST
 
 echo "$NAME : $SHA"
 
-# delete the "name" and "value" lines for the old SHA ONLY FOR OPERANDS
+# delete the "name" and "value" lines for the old SHA ONLY FOR OPERANDS in current CSV
 # for example:
 #     - name: CONTROLLER_IMAGE_TAG_OR_SHA
 #       value: "sha256:10a844ffaf7733176e927e6c4faa04c2bc4410cf4d4ef61b9ae5240aa62d1456"
 
-sed -i "/name: $TYPE/{N;d;}" $FILE
+CSV_VERSION=$(cat version/version.go | grep "Version =" | awk '{ print $3}' | tr -d '"')
 
-# insert the new SHA lines
-LINE1="\            - name: $TYPE"
-LINE2="\              value: \"$SHA\""
-sed -i "/DO NOT DELETE. Add operand image SHAs here./a $LINE1\n$LINE2" $FILE
+CSV_FILE=deploy/olm-catalog/ibm-cert-manager-operator/${CSV_VERSION}/ibm-cert-manager-operator.v${CSV_VERSION}.clusterserviceversion.yaml
+
+echo "Updating operand $TYPE in $CSV_FILE"
+$SED -i "/name: $TYPE/{N;d;}" "$CSV_FILE"
+
+# insert the new SHA lines. need 4 more leading spaces compared to operator.yaml
+LINE1="\                - name: $TYPE"
+LINE2="\                  value: $SHA"
+$SED -i "/env:/a $LINE1\n$LINE2" "$CSV_FILE"
+
+# Not updating the operands anymore in operator.yaml
+# sed -i "/name: $TYPE/{N;d;}" $FILE
+
+# # insert the new SHA lines
+# LINE1="\            - name: $TYPE"
+# LINE2="\              value: \"$SHA\""
+# sed -i "/DO NOT DELETE. Add operand image SHAs here./a $LINE1\n$LINE2" $FILE

--- a/common/scripts/get_image_sha_digest.sh
+++ b/common/scripts/get_image_sha_digest.sh
@@ -29,8 +29,6 @@ if [[ "$unamestr" == "Darwin" ]] ; then
     }
 fi
 
-FILE=deploy/operator.yaml
-
 # check the input parms
 REGISTRY=$1
 NAME=$2
@@ -67,7 +65,13 @@ echo "$NAME : $SHA"
 #     - name: CONTROLLER_IMAGE_TAG_OR_SHA
 #       value: "sha256:10a844ffaf7733176e927e6c4faa04c2bc4410cf4d4ef61b9ae5240aa62d1456"
 
-CSV_VERSION=$(cat version/version.go | grep "Version =" | awk '{ print $3}' | tr -d '"')
+CSV_VERSION=$(< version/version.go grep "Version =" | awk '{ print $3}' | tr -d '"')
+
+if [[ $CSV_VERSION == "" ]]
+then
+    echo "CSV Version not retrieved"
+    exit 1
+fi
 
 CSV_FILE=deploy/olm-catalog/ibm-cert-manager-operator/${CSV_VERSION}/ibm-cert-manager-operator.v${CSV_VERSION}.clusterserviceversion.yaml
 
@@ -80,6 +84,7 @@ LINE2="\                  value: $SHA"
 $SED -i "/env:/a $LINE1\n$LINE2" "$CSV_FILE"
 
 # Not updating the operands anymore in operator.yaml
+# FILE=deploy/operator.yaml
 # sed -i "/name: $TYPE/{N;d;}" $FILE
 
 # # insert the new SHA lines

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.7.0/ibm-cert-manager-operator.v3.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.7.0/ibm-cert-manager-operator.v3.7.0.clusterserviceversion.yaml
@@ -481,6 +481,16 @@ spec:
                 command:
                 - ibm-cert-manager-operator
                 env:
+                - name: CONTROLLER_IMAGE_TAG_OR_SHA
+                  value: sha256:970c7f3d9b8e846bb04cddb3ad30242310f40ebc5038c3146b452c545c064b98
+                - name: WEBHOOK_IMAGE_TAG_OR_SHA
+                  value: sha256:da87f4a30744082aeaa5825eb8a8401e9aa1c1d65cb720cc19f81706856160f4
+                - name: CAINJECTOR_IMAGE_TAG_OR_SHA
+                  value: sha256:06c6e226fc3436e337c967ebf61500aef1cd00e2412027d03e89ae6e4ec9a62f
+                - name: ACMESOLVER_IMAGE_TAG_OR_SHA
+                  value: sha256:5cab268b7d0df423d7a078d2f0fbc5b9f1182a4d13e3acf20f676ca0211ec951
+                - name: CONFIGMAP_WATCHER_IMAGE_TAG_OR_SHA
+                  value: sha256:7701bc70027201b9e9b6d91e5f9eb924a9caadd74ec0ba40de6979da58d3a5a2
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -491,16 +501,6 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: ibm-cert-manager-operator
-                - name: CONTROLLER_IMAGE_TAG_OR_SHA
-                  value: sha256:66bf2088ddb29f5dec85adaef22b2e192843f8fdbc8e203af0f72bb462325551
-                - name: WEBHOOK_IMAGE_TAG_OR_SHA
-                  value: sha256:68d82f5a2649f6b5df916783c7c869bb594b4213010dfda761348bab8fe23d3e
-                - name: CAINJECTOR_IMAGE_TAG_OR_SHA
-                  value: sha256:4a94fb70d5c7d6479869717f50a86a9c85b3e918cc13a882a3a5b5b43cea8ade
-                - name: ACMESOLVER_IMAGE_TAG_OR_SHA
-                  value: sha256:94a464f336b1d3e0aca6c9ac16d537d3642ac77802937999e2c5dd8f0cdaad4d
-                - name: CONFIGMAP_WATCHER_IMAGE_TAG_OR_SHA
-                  value: sha256:7cf856c4ed3e61c256eef3d7312c8358a3f5859029e481fad909d18849db30bd
                 image: quay.io/opencloudio/ibm-cert-manager-operator:latest
                 imagePullPolicy: Always
                 name: ibm-cert-manager-operator

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ibm/ibm-cert-manager-operator
 
-go 1.13
+go 1.14
 
 require (
 	github.com/operator-framework/operator-sdk v0.13.0


### PR DESCRIPTION
- Update operand image SHA digest script to pull from artifactory and update CSV instead of operator.yaml
- Update operand SHA references
- Update go.mod to reflect go version 1.14