### PR TITLE
3.7.1 CSV updates and multi-arch support

### DIFF
--- a/.osdk-scorecard.yaml
+++ b/.osdk-scorecard.yaml
@@ -10,4 +10,4 @@ scorecard:
     - olm:
         cr-manifest:
           - "deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml"
-        csv-path: "deploy/olm-catalog/ibm-cert-manager-operator/3.7.0/ibm-cert-manager-operator.v3.7.0.clusterserviceversion.yaml"
+        csv-path: "deploy/olm-catalog/ibm-cert-manager-operator/3.7.1/ibm-cert-manager-operator.v3.7.1.clusterserviceversion.yaml"

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ bump-csv:
 
 install: ## Install all resources (CR/CRD's, RBAC and Operator)
 	@echo ....... Set environment variables ......
-	- export NAMESPACE=ibm_common_services
+	- export NAMESPACE=ibm-common-services
 	- export BASE_DIR=deploy/olm-catalog/ibm-cert-manager-operator
 	# @echo ....... Creating namespace .......
 	# - kubectl create namespace ${NAMESPACE}
@@ -267,7 +267,7 @@ install: ## Install all resources (CR/CRD's, RBAC and Operator)
 	- for cr in $(shell ls deploy/crds/*_cr.yaml); do kubectl -n ${NAMESPACE} apply -f $${cr}; done
 
 uninstall: ## Uninstall all that all performed in the $ make install
-	- export NAMESPACE=ibm_common_services
+	- export NAMESPACE=ibm-common-services
 	- export BASE_DIR=deploy/olm-catalog/ibm-cert-manager-operator
 	@echo ....... Uninstalling .......
 	@echo ....... Deleting CR .......

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,14 @@ get-configmap-watcher-image-sha:
 	@common/scripts/get_image_sha_digest.sh $(OPERAND_REGISTRY) icp-configmap-watcher $(CONFIGMAP_WATCHER_OPERAND_TAG) CONFIGMAP_WATCHER_IMAGE_TAG_OR_SHA
 
 ############################################################
+# Bump up CSV version
+############################################################
+
+.PHONY: bump-csv
+bump-csv:
+	@common/scripts/bump_up_csv.sh ${NEW_CSV_VERSION}
+
+############################################################
 # application section
 ############################################################
 

--- a/common/scripts/bump_up_csv.sh
+++ b/common/scripts/bump_up_csv.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Create a new version of the operator and update the required files with the new version number.
+#
+# Run this script from the parent dir by typing "scripts/bump-up-csv.sh"
+#
+
+SED="sed"
+unamestr=$(uname)
+if [[ "$unamestr" == "Darwin" ]] ; then
+    SED=gsed
+    type $SED >/dev/null 2>&1 || {
+        echo >&2 "$SED it's not installed. Try: brew install gnu-sed" ;
+        exit 1;
+    }
+fi
+
+# check the input parms
+if [ -z "${1}" ]; then
+    echo "Usage:   $0 [new CSV version]"
+    exit 1
+fi
+
+if [ ! -f "$(command -v yq 2> /dev/null)" ]; then
+    echo "[ERROR] yq command not found"
+    exit 1
+fi
+
+OPERATOR_NAME=ibm-cert-manager-operator
+NEW_CSV_VERSION=${1}
+
+DEPLOY_DIR=${DEPLOY_DIR:-deploy}
+BUNDLE_DIR=${BUNDLE_DIR:-deploy/olm-catalog/${OPERATOR_NAME}}
+# get the version number for the current/last CSV
+LAST_CSV_DIR=$(find "${BUNDLE_DIR}" -maxdepth 1 -type d | sort | tail -1)
+LAST_CSV_VERSION=$(basename "${LAST_CSV_DIR}")
+NEW_CSV_DIR=${LAST_CSV_DIR//${LAST_CSV_VERSION}/${NEW_CSV_VERSION}}
+
+PREVIOUS_CSV_DIR=$(find "${BUNDLE_DIR}" -maxdepth 1 -type d | sort | tail -2 | head -1)
+PREVIOUS_CSV_VERSION=$(basename "${PREVIOUS_CSV_DIR}")
+
+if [ "${LAST_CSV_VERSION}" == "${NEW_CSV_VERSION}" ]; then
+    echo "Last CSV version is already at ${NEW_CSV_VERSION}"
+    exit 1
+fi
+
+echo "******************************************"
+echo " PREVIOUS_CSV_VERSION:  $PREVIOUS_CSV_VERSION"
+echo " CURRENT_CSV_VERSION:   $LAST_CSV_VERSION"
+echo " NEW_CSV_VERSION:       $NEW_CSV_VERSION"
+echo "******************************************"
+echo "Does the above look correct? (y/n) "
+read -r ANSWER
+if [[ "$ANSWER" != "y" ]]
+then
+  echo "Not going to bump up CSV version"
+  exit 1
+fi
+
+echo -e "\n[INFO] Bumping up CSV version from ${LAST_CSV_VERSION} to ${NEW_CSV_VERSION}\n"
+
+cp -rfv "${LAST_CSV_DIR}" "${NEW_CSV_DIR}"
+OLD_CSV_FILE=$(find "${NEW_CSV_DIR}" -type f -name '*.clusterserviceversion.yaml' | head -1)
+NEW_CSV_FILE=${OLD_CSV_FILE//${LAST_CSV_VERSION}.clusterserviceversion.yaml/${NEW_CSV_VERSION}.clusterserviceversion.yaml}
+if [ -f "${OLD_CSV_FILE}" ]; then
+    mv -v "${OLD_CSV_FILE}" "${NEW_CSV_FILE}"
+fi
+
+echo -e "\n[INFO] Updating ${NEW_CSV_FILE} from ${OLD_CSV_FILE}"
+
+REPLACES_VERSION=$(yq r "${NEW_CSV_FILE}" "metadata.name")
+CURR_TIME=$(TZ=":UTC" date  +'%FT%R:00Z')
+
+#---------------------------------------------------------
+# update the CSV file
+#---------------------------------------------------------
+$SED -e "s|name: ${OPERATOR_NAME}\(.*\)${LAST_CSV_VERSION}|name: ${OPERATOR_NAME}\1${NEW_CSV_VERSION}|" -i "${NEW_CSV_FILE}"
+$SED -e "s|olm.skipRange: \(.*\)${LAST_CSV_VERSION}\(.*\)|olm.skipRange: \1${NEW_CSV_VERSION}\2|" -i "${NEW_CSV_FILE}"
+$SED -e "s|image: \(.*\)${OPERATOR_NAME}\(.*\)|image: \1${OPERATOR_NAME}:latest|" -i "${NEW_CSV_FILE}"
+$SED -e "s|containerImage: \(.*\)${OPERATOR_NAME}\(.*\)|containerImage: \1${OPERATOR_NAME}:${NEW_CSV_VERSION}|" -i "${NEW_CSV_FILE}"
+$SED -e "s|replaces: ${OPERATOR_NAME}\(.*\)${PREVIOUS_CSV_VERSION}|replaces: ${REPLACES_VERSION}|" -i "${NEW_CSV_FILE}"
+# update the operator version - version: 3.6.2
+$SED -e "s|version: ${LAST_CSV_VERSION}|version: ${NEW_CSV_VERSION}|" -i "${NEW_CSV_FILE}"
+# update the 'version' field for each CR in the CSV - "version": "3.6.3"
+$SED -e "s|\"version\": \"${LAST_CSV_VERSION}\"|\"version\": \"${NEW_CSV_VERSION}\"|g" -i "${NEW_CSV_FILE}"
+# update the 'createdAt' date. example:
+#   createdAt: "2020-06-29T21:46:35Z"
+#                           YYYY    -    MM    -    DD    T    HH    :   MM     :   SS     Z
+#                       +----------+ +--------+ +--------+ +--------+ +--------+ +--------+
+$SED -e "s|createdAt: \"\([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}T[0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}Z\)\"|createdAt: \"${CURR_TIME}\"|" -i "${NEW_CSV_FILE}"
+
+#---------------------------------------------------------
+# update package.yaml
+#---------------------------------------------------------
+PACKAGE_YAML=${BUNDLE_DIR}/${OPERATOR_NAME}.package.yaml
+if ! [ -f "${PACKAGE_YAML}" ]; then
+    echo "[WARN] ${PACKAGE_YAML} does not exist."
+    exit 1
+fi
+echo -e "\n[INFO] Updating 'dev' channel in ${PACKAGE_YAML}"
+NEW_VERSION=$(yq r "${NEW_CSV_FILE}" "metadata.name")
+yq w -i "${PACKAGE_YAML}" "channels.(name==dev).currentCSV" "${NEW_VERSION}" 
+
+# remove the leading spaces added by "yq"
+$SED -e "s|  - currentCSV:|- currentCSV:|g" -i "${PACKAGE_YAML}"
+$SED -e "s|    name:|  name:|g" -i "${PACKAGE_YAML}"
+
+#---------------------------------------------------------
+# update operator.yaml
+#---------------------------------------------------------
+OPERATOR_YAML=${DEPLOY_DIR}/operator.yaml
+if ! [ -f "${OPERATOR_YAML}" ]; then
+    echo "[WARN] ${OPERATOR_YAML} does not exist."
+    exit 1
+fi
+echo -e "\n[INFO] Updating 'image tag' in ${OPERATOR_YAML}"
+$SED -e "s|image: \(.*\)${OPERATOR_NAME}\(.*\)|image: \1${OPERATOR_NAME}:latest|" -i "${OPERATOR_YAML}"
+
+#---------------------------------------------------------
+# update the version in certmanager CR yaml file
+#---------------------------------------------------------
+echo -e "\n[INFO] Updating 'version' in certmanager CR yaml"
+$SED -e "s|version: \"${LAST_CSV_VERSION}\"|version: \"${NEW_CSV_VERSION}\"|" -i "${DEPLOY_DIR}/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml"
+
+#---------------------------------------------------------
+# update version.go
+#---------------------------------------------------------
+VERSION_GO="version/version.go"
+if ! [ -f "${VERSION_GO}" ]; then
+    echo "[WARN] ${VERSION_GO} does not exist."
+    exit 1
+fi
+echo -e "\n[INFO] Updating 'version' in ${VERSION_GO}"
+$SED -e "s|Version\(.*\)${LAST_CSV_VERSION}\(.*\)|Version\1${NEW_CSV_VERSION}\2|" -i "${VERSION_GO}"
+
+#---------------------------------------------------------
+# update .osdk-scorecard.yaml
+#---------------------------------------------------------
+if [ -f ".osdk-scorecard.yaml" ]; then
+    echo -e "\n[INFO] Updating 'version' in .osdk-scorecard.yaml"
+    $SED -e "s|${LAST_CSV_VERSION}|${NEW_CSV_VERSION}|g" -i .osdk-scorecard.yaml
+fi

--- a/deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml
@@ -10,6 +10,6 @@ spec:
   disableHostNetwork: true
   enableWebhook: true
   imageRegistry: quay.io/opencloudio
-  version: "3.7.0"
+  version: "3.7.1"
 status:
   certManagerStatus: ''

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.7.1/certificate-crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.7.1/certificate-crd.yaml
@@ -1,0 +1,299 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.certmanager.k8s.io
+  labels:
+    app.kubernetes.io/instance: ibm-cert-manager-operator
+    app.kubernetes.io/managed-by: ibm-cert-manager-operator
+    app.kubernetes.io/name: cert-manager
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - JSONPath: .spec.secretName
+      name: Secret
+      type: string
+    - JSONPath: .spec.issuerRef.name
+      name: Issuer
+      type: string
+      priority: 1
+    - JSONPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+      priority: 1
+    - JSONPath: .metadata.creationTimestamp
+      description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        \nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+      name: Age
+      type: date
+    - JSONPath: .status.notAfter
+      name: Expiration
+      type: string
+  group: certmanager.k8s.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: Certificate
+    plural: certificates
+    shortNames:
+      - cert
+      - certs
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: Certificate is a type to represent a Certificate from ACME
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CertificateSpec defines the desired state of Certificate
+          properties:
+            acme:
+              description: ACME contains configuration specific to ACME Certificates.
+                Notably, this contains details on how the domain names listed on this
+                Certificate resource should be 'solved', i.e. mapping HTTP01 and DNS01
+                providers to DNS names.
+              properties:
+                config:
+                  items:
+                    description: DomainSolverConfig contains solver configuration
+                      for a set of domains.
+                    properties:
+                      dns01:
+                        description: DNS01 contains DNS01 challenge solving configuration
+                        properties:
+                          provider:
+                            description: Provider is the name of the DNS01 challenge
+                              provider to use, as configure on the referenced Issuer
+                              or ClusterIssuer resource.
+                            type: string
+                        required:
+                        - provider
+                        type: object
+                      domains:
+                        description: Domains is the list of domains that this SolverConfig
+                          applies to.
+                        items:
+                          type: string
+                        type: array
+                      http01:
+                        description: HTTP01 contains HTTP01 challenge solving configuration
+                        properties:
+                          ingress:
+                            description: Ingress is the name of an Ingress resource
+                              that will be edited to include the ACME HTTP01 'well-known'
+                              challenge path in order to solve HTTP01 challenges.
+                              If this field is specified, 'ingressClass' **must not**
+                              be specified.
+                            type: string
+                          ingressClass:
+                            description: IngressClass is the ingress class that should
+                              be set on new ingress resources that are created in
+                              order to solve HTTP01 challenges. This field should
+                              be used when using an ingress controller such as nginx,
+                              which 'flattens' ingress configuration instead of maintaining
+                              a 1:1 mapping between loadbalancer IP:ingress resources.
+                              If this field is not set, and 'ingress' is not set,
+                              then ingresses without an ingress class set will be
+                              created to solve HTTP01 challenges. If this field is
+                              specified, 'ingress' **must not** be specified.
+                            type: string
+                        type: object
+                    required:
+                    - domains
+                    type: object
+                  type: array
+              required:
+              - config
+              type: object
+            commonName:
+              description: CommonName is a common name to be used on the Certificate.
+                If no CommonName is given, then the first entry in DNSNames is used
+                as the CommonName. The CommonName should have a length of 64 characters
+                or fewer to avoid generating invalid CSRs; in order to have longer
+                domain names, set the CommonName (or first DNSNames entry) to have
+                64 characters or fewer, and then add the longer domain name to DNSNames.
+              type: string
+            dnsNames:
+              description: DNSNames is a list of subject alt names to be used on the
+                Certificate. If no CommonName is given, then the first entry in DNSNames
+                is used as the CommonName and must have a length of 64 characters
+                or fewer.
+              items:
+                type: string
+              type: array
+            duration:
+              description: Certificate default Duration
+              type: string
+            ipAddresses:
+              description: IPAddresses is a list of IP addresses to be used on the
+                Certificate
+              items:
+                type: string
+              type: array
+            isCA:
+              description: IsCA will mark this Certificate as valid for signing. This
+                implies that the 'cert sign' usage is set
+              type: boolean
+            issuerRef:
+              description: IssuerRef is a reference to the issuer for this certificate.
+                If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                with the given name in the same namespace as the Certificate will
+                be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                with the provided name will be used. The 'name' field in this stanza
+                is required at all times.
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+            keyAlgorithm:
+              description: KeyAlgorithm is the private key algorithm of the corresponding
+                private key for this certificate. If provided, allowed values are
+                either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
+                not provided, key size of 256 will be used for "ecdsa" key algorithm
+                and key size of 2048 will be used for "rsa" key algorithm.
+              enum:
+              - rsa
+              - ecdsa
+              type: string
+            keyEncoding:
+              description: KeyEncoding is the private key cryptography standards (PKCS)
+                for this certificate's private key to be encoded in. If provided,
+                allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
+                respectively. If KeyEncoding is not specified, then PKCS#1 will be
+                used by default.
+              enum:
+              - pkcs1
+              - pkcs8
+              type: string
+            keySize:
+              description: KeySize is the key bit size of the corresponding private
+                key for this certificate. If provided, value must be between 2048
+                and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                to "ecdsa".
+              type: integer
+            organization:
+              description: Organization is the organization to be used on the Certificate
+              items:
+                type: string
+              type: array
+            renewBefore:
+              description: Certificate renew before expiration duration
+              type: string
+            secretName:
+              description: SecretName is the name of the secret resource to store
+                this secret in
+              type: string
+            usages:
+              description: Usages is the set of x509 actions that are enabled for
+                a given key. Defaults are ('digital signature', 'key encipherment')
+                if empty
+              items:
+                description: 'KeyUsage specifies valid usage contexts for keys. See:
+                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12'
+                enum:
+                - signing
+                - digital signature
+                - content commitment
+                - key encipherment
+                - key agreement
+                - data encipherment
+                - cert sign
+                - crl sign
+                - encipher only
+                - decipher only
+                - any
+                - server auth
+                - client auth
+                - code signing
+                - email protection
+                - s/mime
+                - ipsec end system
+                - ipsec tunnel
+                - ipsec user
+                - timestamping
+                - ocsp signing
+                - microsoft sgc
+                - netscape sgc
+                type: string
+              type: array
+          required:
+          - issuerRef
+          - secretName
+          type: object
+        status:
+          description: CertificateStatus defines the observed state of Certificate
+          properties:
+            conditions:
+              items:
+                description: CertificateCondition contains condition information for
+                  an Certificate.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            lastFailureTime:
+              format: date-time
+              type: string
+            notAfter:
+              description: The expiration time of the certificate stored in the secret
+                named by this resource in spec.secretName.
+              format: date-time
+              type: string
+          type: object
+      type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.7.1/clusterissuer-crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.7.1/clusterissuer-crd.yaml
@@ -1,0 +1,1981 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: clusterissuers.certmanager.k8s.io
+  labels:
+    app.kubernetes.io/instance: ibm-cert-manager-operator
+    app.kubernetes.io/managed-by: ibm-cert-manager-operator
+    app.kubernetes.io/name: cert-manager
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: ClusterIssuer
+    plural: clusterissuers
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IssuerSpec is the specification of an Issuer. This includes
+            any configuration required for the issuer.
+          properties:
+            acme:
+              description: ACMEIssuer contains the specification for an ACME issuer
+              properties:
+                dns01:
+                  description: 'DEPRECATED: DNS-01 config'
+                  properties:
+                    providers:
+                      items:
+                        description: ACMEIssuerDNS01Provider contains configuration
+                          for a DNS provider that can be used to solve ACME DNS01
+                          challenges.
+                        properties:
+                          acmedns:
+                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                              containing the configuration for ACME-DNS servers
+                            properties:
+                              accountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              host:
+                                type: string
+                            required:
+                            - accountSecretRef
+                            - host
+                            type: object
+                          akamai:
+                            description: ACMEIssuerDNS01ProviderAkamai is a structure
+                              containing the DNS configuration for Akamai DNS—Zone
+                              Record Management API
+                            properties:
+                              accessTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              serviceConsumerDomain:
+                                type: string
+                            required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                            type: object
+                          azuredns:
+                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                              containing the configuration for Azure DNS
+                            properties:
+                              clientID:
+                                type: string
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                                type: string
+                              hostedZoneName:
+                                type: string
+                              resourceGroupName:
+                                type: string
+                              subscriptionID:
+                                type: string
+                              tenantID:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecretSecretRef
+                            - resourceGroupName
+                            - subscriptionID
+                            - tenantID
+                            type: object
+                          clouddns:
+                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                              containing the DNS configuration for Google Cloud DNS
+                            properties:
+                              project:
+                                type: string
+                              serviceAccountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - project
+                            - serviceAccountSecretRef
+                            type: object
+                          cloudflare:
+                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                              containing the DNS configuration for Cloudflare
+                            properties:
+                              apiKeySecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              email:
+                                type: string
+                            required:
+                            - apiKeySecretRef
+                            - email
+                            type: object
+                          cnameStrategy:
+                            description: CNAMEStrategy configures how the DNS01 provider
+                              should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
+                            type: string
+                          digitalocean:
+                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                              structure containing the DNS configuration for DigitalOcean
+                              Domains
+                            properties:
+                              tokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - tokenSecretRef
+                            type: object
+                          name:
+                            description: Name is the name of the DNS provider, which
+                              should be used to reference this DNS provider configuration
+                              on Certificate resources.
+                            type: string
+                          rfc2136:
+                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                              containing the configuration for RFC2136 DNS
+                            properties:
+                              nameserver:
+                                description: 'The IP address of the DNS supporting
+                                  RFC2136. Required. Note: FQDN is not a valid value,
+                                  only IP.'
+                                type: string
+                              tsigAlgorithm:
+                                description: 'The TSIG Algorithm configured in the
+                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                  and ``tsigKeyName`` are defined. Supported values
+                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                  ``HMACSHA256`` or ``HMACSHA512``.'
+                                type: string
+                              tsigKeyName:
+                                description: The TSIG Key name configured in the DNS.
+                                  If ``tsigSecretSecretRef`` is defined, this field
+                                  is required.
+                                type: string
+                              tsigSecretSecretRef:
+                                description: The name of the secret containing the
+                                  TSIG value. If ``tsigKeyName`` is defined, this
+                                  field is required.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - nameserver
+                            type: object
+                          route53:
+                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                              containing the Route 53 configuration for AWS
+                            properties:
+                              accessKeyID:
+                                description: 'The AccessKeyID is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                type: string
+                              hostedZoneID:
+                                description: If set, the provider will manage only
+                                  this zone in Route53 and will not do an lookup using
+                                  the route53:ListHostedZonesByName api call.
+                                type: string
+                              region:
+                                description: Always set the region when using AccessKeyID
+                                  and SecretAccessKey
+                                type: string
+                              role:
+                                description: Role is a Role ARN which the Route53
+                                  provider will assume using either the explicit credentials
+                                  AccessKeyID/SecretAccessKey or the inferred credentials
+                                  from environment variables, shared credentials file
+                                  or AWS Instance metadata
+                                type: string
+                              secretAccessKeySecretRef:
+                                description: The SecretAccessKey is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - region
+                            type: object
+                          webhook:
+                            description: ACMEIssuerDNS01ProviderWebhook specifies
+                              configuration for a webhook DNS01 provider, including
+                              where to POST ChallengePayload resources.
+                            properties:
+                              config:
+                                description: Additional configuration that should
+                                  be passed to the webhook apiserver when challenges
+                                  are processed. This can contain arbitrary JSON data.
+                                  Secret values should not be specified in this stanza.
+                                  If secret values are needed (e.g. credentials for
+                                  a DNS service), you should use a SecretKeySelector
+                                  to reference a Secret resource. For details on the
+                                  schema of this field, consult the webhook provider
+                                  implementation's documentation.
+                                type: object
+                              groupName:
+                                description: The API group name that should be used
+                                  when POSTing ChallengePayload resources to the webhook
+                                  apiserver. This should be the same as the GroupName
+                                  specified in the webhook provider implementation.
+                                type: string
+                              solverName:
+                                description: The name of the solver to use, as defined
+                                  in the webhook provider implementation. This will
+                                  typically be the name of the provider, e.g. 'cloudflare'.
+                                type: string
+                            required:
+                            - groupName
+                            - solverName
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                  type: object
+                email:
+                  description: Email is the email for this account
+                  type: string
+                http01:
+                  description: 'DEPRECATED: HTTP-01 config'
+                  properties:
+                    serviceType:
+                      description: Optional service type for Kubernetes solver service
+                      type: string
+                  type: object
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  properties:
+                    key:
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  required:
+                  - name
+                  type: object
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+                solvers:
+                  description: Solvers is a list of challenge solvers that will be
+                    used to solve ACME challenges for the matching domains.
+                  items:
+                    properties:
+                      dns01:
+                        properties:
+                          acmedns:
+                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                              containing the configuration for ACME-DNS servers
+                            properties:
+                              accountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              host:
+                                type: string
+                            required:
+                            - accountSecretRef
+                            - host
+                            type: object
+                          akamai:
+                            description: ACMEIssuerDNS01ProviderAkamai is a structure
+                              containing the DNS configuration for Akamai DNS—Zone
+                              Record Management API
+                            properties:
+                              accessTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              serviceConsumerDomain:
+                                type: string
+                            required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                            type: object
+                          azuredns:
+                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                              containing the configuration for Azure DNS
+                            properties:
+                              clientID:
+                                type: string
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                                type: string
+                              hostedZoneName:
+                                type: string
+                              resourceGroupName:
+                                type: string
+                              subscriptionID:
+                                type: string
+                              tenantID:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecretSecretRef
+                            - resourceGroupName
+                            - subscriptionID
+                            - tenantID
+                            type: object
+                          clouddns:
+                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                              containing the DNS configuration for Google Cloud DNS
+                            properties:
+                              project:
+                                type: string
+                              serviceAccountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - project
+                            - serviceAccountSecretRef
+                            type: object
+                          cloudflare:
+                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                              containing the DNS configuration for Cloudflare
+                            properties:
+                              apiKeySecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              email:
+                                type: string
+                            required:
+                            - apiKeySecretRef
+                            - email
+                            type: object
+                          cnameStrategy:
+                            description: CNAMEStrategy configures how the DNS01 provider
+                              should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
+                            type: string
+                          digitalocean:
+                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                              structure containing the DNS configuration for DigitalOcean
+                              Domains
+                            properties:
+                              tokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - tokenSecretRef
+                            type: object
+                          rfc2136:
+                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                              containing the configuration for RFC2136 DNS
+                            properties:
+                              nameserver:
+                                description: 'The IP address of the DNS supporting
+                                  RFC2136. Required. Note: FQDN is not a valid value,
+                                  only IP.'
+                                type: string
+                              tsigAlgorithm:
+                                description: 'The TSIG Algorithm configured in the
+                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                  and ``tsigKeyName`` are defined. Supported values
+                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                  ``HMACSHA256`` or ``HMACSHA512``.'
+                                type: string
+                              tsigKeyName:
+                                description: The TSIG Key name configured in the DNS.
+                                  If ``tsigSecretSecretRef`` is defined, this field
+                                  is required.
+                                type: string
+                              tsigSecretSecretRef:
+                                description: The name of the secret containing the
+                                  TSIG value. If ``tsigKeyName`` is defined, this
+                                  field is required.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - nameserver
+                            type: object
+                          route53:
+                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                              containing the Route 53 configuration for AWS
+                            properties:
+                              accessKeyID:
+                                description: 'The AccessKeyID is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                type: string
+                              hostedZoneID:
+                                description: If set, the provider will manage only
+                                  this zone in Route53 and will not do an lookup using
+                                  the route53:ListHostedZonesByName api call.
+                                type: string
+                              region:
+                                description: Always set the region when using AccessKeyID
+                                  and SecretAccessKey
+                                type: string
+                              role:
+                                description: Role is a Role ARN which the Route53
+                                  provider will assume using either the explicit credentials
+                                  AccessKeyID/SecretAccessKey or the inferred credentials
+                                  from environment variables, shared credentials file
+                                  or AWS Instance metadata
+                                type: string
+                              secretAccessKeySecretRef:
+                                description: The SecretAccessKey is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - region
+                            type: object
+                          webhook:
+                            description: ACMEIssuerDNS01ProviderWebhook specifies
+                              configuration for a webhook DNS01 provider, including
+                              where to POST ChallengePayload resources.
+                            properties:
+                              config:
+                                description: Additional configuration that should
+                                  be passed to the webhook apiserver when challenges
+                                  are processed. This can contain arbitrary JSON data.
+                                  Secret values should not be specified in this stanza.
+                                  If secret values are needed (e.g. credentials for
+                                  a DNS service), you should use a SecretKeySelector
+                                  to reference a Secret resource. For details on the
+                                  schema of this field, consult the webhook provider
+                                  implementation's documentation.
+                                type: object
+                              groupName:
+                                description: The API group name that should be used
+                                  when POSTing ChallengePayload resources to the webhook
+                                  apiserver. This should be the same as the GroupName
+                                  specified in the webhook provider implementation.
+                                type: string
+                              solverName:
+                                description: The name of the solver to use, as defined
+                                  in the webhook provider implementation. This will
+                                  typically be the name of the provider, e.g. 'cloudflare'.
+                                type: string
+                            required:
+                            - groupName
+                            - solverName
+                            type: object
+                        type: object
+                      http01:
+                        description: ACMEChallengeSolverHTTP01 contains configuration
+                          detailing how to solve HTTP01 challenges within a Kubernetes
+                          cluster. Typically this is accomplished through creating
+                          'routes' of some description that configure ingress controllers
+                          to direct traffic to 'solver pods', which are responsible
+                          for responding to the ACME server's HTTP requests.
+                        properties:
+                          ingress:
+                            description: The ingress based HTTP01 challenge solver
+                              will solve challenges by creating or modifying Ingress
+                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                              to 'challenge solver' pods that are provisioned by cert-manager
+                              for each Challenge to be completed.
+                            properties:
+                              class:
+                                description: The ingress class to use when creating
+                                  Ingress resources to solve ACME challenges that
+                                  use this challenge solver. Only one of 'class' or
+                                  'name' may be specified.
+                                type: string
+                              name:
+                                description: The name of the ingress resource that
+                                  should have ACME challenge solving routes inserted
+                                  into it in order to solve HTTP01 challenges. This
+                                  is typically used in conjunction with ingress controllers
+                                  like ingress-gce, which maintains a 1:1 mapping
+                                  between external IPs and ingress resources.
+                                type: string
+                              podTemplate:
+                                description: Optional pod template used to configure
+                                  the ACME challenge solver pods used for HTTP01 challenges
+                                properties:
+                                  metadata:
+                                    description: ObjectMeta overrides for the pod
+                                      used to solve HTTP01 challenges. Only the 'labels'
+                                      and 'annotations' fields may be set. If labels
+                                      or annotations overlap with in-built values,
+                                      the values here will override the in-built values.
+                                    type: object
+                                  spec:
+                                    description: PodSpec defines overrides for the
+                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                      'affinity' and 'tolerations' fields are supported
+                                      currently. All other fields will be ignored.
+                                    properties:
+                                      affinity:
+                                        description: If specified, the pod's scheduling
+                                          constraints
+                                        properties:
+                                          nodeAffinity:
+                                            description: Describes node affinity scheduling
+                                              rules for the pod.
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node matches the
+                                                  corresponding matchExpressions;
+                                                  the node(s) with the highest sum
+                                                  are the most preferred.
+                                                items:
+                                                  description: An empty preferred
+                                                    scheduling term matches all objects
+                                                    with implicit weight 0 (i.e. it's
+                                                    a no-op). A null preferred scheduling
+                                                    term matches no objects (i.e.
+                                                    is also a no-op).
+                                                  properties:
+                                                    preference:
+                                                      description: A node selector
+                                                        term, associated with the
+                                                        corresponding weight.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    weight:
+                                                      description: Weight associated
+                                                        with matching the corresponding
+                                                        nodeSelectorTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to an update), the system
+                                                  may or may not try to eventually
+                                                  evict the pod from its node.
+                                                properties:
+                                                  nodeSelectorTerms:
+                                                    description: Required. A list
+                                                      of node selector terms. The
+                                                      terms are ORed.
+                                                    items:
+                                                      description: A null or empty
+                                                        node selector term matches
+                                                        no objects. The requirements
+                                                        of them are ANDed. The TopologySelectorTerm
+                                                        type implements a subset of
+                                                        the NodeSelectorTerm.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                required:
+                                                - nodeSelectorTerms
+                                                type: object
+                                            type: object
+                                          podAffinity:
+                                            description: Describes pod affinity scheduling
+                                              rules (e.g. co-locate this pod in the
+                                              same node, zone, etc. as some other
+                                              pod(s)).
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node has pods
+                                                  which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to a pod label update),
+                                                  the system may or may not try to
+                                                  eventually evict the pod from its
+                                                  node. When there are multiple elements,
+                                                  the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          podAntiAffinity:
+                                            description: Describes pod anti-affinity
+                                              scheduling rules (e.g. avoid putting
+                                              this pod in the same node, zone, etc.
+                                              as some other pod(s)).
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the anti-affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  anti-affinity expressions, etc.),
+                                                  compute a sum by iterating through
+                                                  the elements of this field and adding
+                                                  "weight" to the sum if the node
+                                                  has pods which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the anti-affinity
+                                                  requirements specified by this field
+                                                  are not met at scheduling time,
+                                                  the pod will not be scheduled onto
+                                                  the node. If the anti-affinity requirements
+                                                  specified by this field cease to
+                                                  be met at some point during pod
+                                                  execution (e.g. due to a pod label
+                                                  update), the system may or may not
+                                                  try to eventually evict the pod
+                                                  from its node. When there are multiple
+                                                  elements, the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                        type: object
+                                      nodeSelector:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'NodeSelector is a selector which
+                                          must be true for the pod to fit on a node.
+                                          Selector which must match a node''s labels
+                                          for the pod to be scheduled on that node.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                        type: object
+                                      tolerations:
+                                        description: If specified, the pod's tolerations.
+                                        items:
+                                          description: The pod this Toleration is
+                                            attached to tolerates any taint that matches
+                                            the triple <key,value,effect> using the
+                                            matching operator <operator>.
+                                          properties:
+                                            effect:
+                                              description: Effect indicates the taint
+                                                effect to match. Empty means match
+                                                all taint effects. When specified,
+                                                allowed values are NoSchedule, PreferNoSchedule
+                                                and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Key is the taint key that
+                                                the toleration applies to. Empty means
+                                                match all taint keys. If the key is
+                                                empty, operator must be Exists; this
+                                                combination means to match all values
+                                                and all keys.
+                                              type: string
+                                            operator:
+                                              description: Operator represents a key's
+                                                relationship to the value. Valid operators
+                                                are Exists and Equal. Defaults to
+                                                Equal. Exists is equivalent to wildcard
+                                                for value, so that a pod can tolerate
+                                                all taints of a particular category.
+                                              type: string
+                                            tolerationSeconds:
+                                              description: TolerationSeconds represents
+                                                the period of time the toleration
+                                                (which must be of effect NoExecute,
+                                                otherwise this field is ignored) tolerates
+                                                the taint. By default, it is not set,
+                                                which means tolerate the taint forever
+                                                (do not evict). Zero and negative
+                                                values will be treated as 0 (evict
+                                                immediately) by the system.
+                                              format: int64
+                                              type: integer
+                                            value:
+                                              description: Value is the taint value
+                                                the toleration matches to. If the
+                                                operator is Exists, the value should
+                                                be empty, otherwise just a regular
+                                                string.
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              serviceType:
+                                description: Optional service type for Kubernetes
+                                  solver service
+                                type: string
+                            type: object
+                        type: object
+                      selector:
+                        description: Selector selects a set of DNSNames on the Certificate
+                          resource that should be solved using this challenge solver.
+                        properties:
+                          dnsNames:
+                            description: List of DNSNames that this solver will be
+                              used to solve. If specified and a match is found, a
+                              dnsNames selector will take precedence over a dnsZones
+                              selector. If multiple solvers match with the same dnsNames
+                              value, the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          dnsZones:
+                            description: List of DNSZones that this solver will be
+                              used to solve. The most specific DNS zone match specified
+                              here will take precedence over other DNS zone matches,
+                              so a solver specifying sys.example.com will be selected
+                              over one specifying example.com for the domain www.sys.example.com.
+                              If multiple solvers match with the same dnsZones value,
+                              the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: A label selector that is used to refine the
+                              set of certificate's that this challenge solver will
+                              apply to.
+                            type: object
+                        type: object
+                    type: object
+                  type: array
+              required:
+              - privateKeySecretRef
+              - server
+              type: object
+            ca:
+              properties:
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+              required:
+              - secretName
+              type: object
+            selfSigned:
+              type: object
+            vault:
+              properties:
+                auth:
+                  description: Vault authentication
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+              required:
+              - auth
+              - path
+              - server
+              type: object
+            venafi:
+              description: VenafiIssuer describes issuer configuration details for
+                Venafi Cloud.
+              properties:
+                cloud:
+                  description: Cloud specifies the Venafi cloud configuration settings.
+                    Only one of TPP or Cloud may be specified.
+                  properties:
+                    apiTokenSecretRef:
+                      description: APITokenSecretRef is a secret key selector for
+                        the Venafi Cloud API token.
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for Venafi Cloud
+                      type: string
+                  required:
+                  - apiTokenSecretRef
+                  - url
+                  type: object
+                tpp:
+                  description: TPP specifies Trust Protection Platform configuration
+                    settings. Only one of TPP or Cloud may be specified.
+                  properties:
+                    caBundle:
+                      description: CABundle is a PEM encoded TLS certifiate to use
+                        to verify connections to the TPP instance. If specified, system
+                        roots will not be used and the issuing CA for the TPP instance
+                        must be verifiable using the provided root. If not specified,
+                        the connection will be verified using the cert-manager system
+                        root certificates.
+                      format: byte
+                      type: string
+                    credentialsRef:
+                      description: CredentialsRef is a reference to a Secret containing
+                        the username and password for the TPP server. The secret must
+                        contain two keys, 'username' and 'password'.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for the Venafi TPP instance
+                      type: string
+                  required:
+                  - credentialsRef
+                  - url
+                  type: object
+                zone:
+                  description: Zone is the Venafi Policy Zone to use for this issuer.
+                    All requests made to the Venafi platform will be restricted by
+                    the named zone policy. This field is required.
+                  type: string
+              required:
+              - zone
+              type: object
+          type: object
+        status:
+          description: IssuerStatus contains status information about an Issuer
+          properties:
+            acme:
+              properties:
+                lastRegisteredEmail:
+                  description: LastRegisteredEmail is the email associated with the
+                    latest registered ACME account, in order to track changes made
+                    to registered account associated with the  Issuer
+                  type: string
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+              type: object
+            conditions:
+              items:
+                description: IssuerCondition contains condition information for an
+                  Issuer.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.7.1/ibm-cert-manager-operator.v3.7.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.7.1/ibm-cert-manager-operator.v3.7.1.clusterserviceversion.yaml
@@ -1,0 +1,545 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    olm.skipRange: '>=3.5.0 <3.7.1'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "CertManager",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-cert-manager-operator",
+              "app.kubernetes.io/managed-by": "ibm-cert-manager-operator",
+              "app.kubernetes.io/name": "cert-manager"
+            },
+            "name": "default"
+          },
+          "spec": {
+            "disableHostNetwork": true,
+            "enableWebhook": true,
+            "imageRegistry": "quay.io/opencloudio",
+            "version": "3.7.1"
+          },
+          "status": {
+            "certManagerStatus": ""
+          }
+        },
+        {
+          "apiVersion": "certmanager.k8s.io/v1alpha1",
+          "kind": "Issuer",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-cert-manager-operator",
+              "app.kubernetes.io/managed-by": "ibm-cert-manager-operator",
+              "app.kubernetes.io/name": "cert-manager"
+            },
+            "name": "cs-ss-issuer",
+            "namespace": "ibm-common-services"
+          },
+          "spec": {
+            "selfSigned": {}
+          }
+        },
+        {
+          "apiVersion": "certmanager.k8s.io/v1alpha1",
+          "kind": "Certificate",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-cert-manager-operator",
+              "app.kubernetes.io/managed-by": "ibm-cert-manager-operator",
+              "app.kubernetes.io/name": "cert-manager"
+            },
+            "name": "cs-ca-certificate",
+            "namespace": "ibm-common-services"
+          },
+          "spec": {
+            "secretName": "cs-ca-certificate-secret",
+            "issuerRef": {
+              "name": "cs-ss-issuer",
+              "kind": "Issuer"
+            },
+            "commonName": "cs-ca-certificate",
+            "isCA": true
+          }
+        },
+        {
+          "apiVersion": "certmanager.k8s.io/v1alpha1",
+          "kind": "ClusterIssuer",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-cert-manager-operator",
+              "app.kubernetes.io/managed-by": "ibm-cert-manager-operator",
+              "app.kubernetes.io/name": "cert-manager"
+            },
+            "name": "cs-ca-clusterissuer"
+          },
+          "spec": {
+            "ca": {
+              "secretName": "cs-ca-certificate-secret"
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Security
+    certified: "false"
+    containerImage: quay.io/opencloudio/ibm-cert-manager-operator:3.7.1
+    createdAt: "2020-09-01T21:35:00Z"
+    description: Operator for managing deployment of cert-manager service.
+    support: IBM
+  name: ibm-cert-manager-operator.v3.7.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents a certificate
+      displayName: Certificate
+      kind: Certificate
+      name: certificates.certmanager.k8s.io
+      version: v1alpha1
+    - description: Represents a cluster issuer
+      displayName: Cluster Issuer
+      kind: ClusterIssuer
+      name: clusterissuers.certmanager.k8s.io
+      version: v1alpha1
+    - description: Represents an issuer
+      displayName: Issuer
+      kind: Issuer
+      name: issuers.certmanager.k8s.io
+      version: v1alpha1
+    - description: CertManager is the Schema for the certmanagers API
+      kind: CertManager
+      name: certmanagers.operator.ibm.com
+      statusDescriptors:
+      - description: It will be as "OK when all objects are created successfully
+        displayName: CertManager Status
+        path: certManagerStatus
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+      version: v1alpha1
+      displayName: CertManager
+      resources:
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ClusterRole
+        name: clusterroles.rbac.authorization.k8s.io
+        version: v1
+      - kind: ClusterRoleBinding
+        name: clusterrolebindings.rbac.authorization.k8s.io
+        version: v1
+      - kind: CustomResourceDefinition
+        name: customresourcedefinitions.apiextensions.k8s.io
+        version: v1beta1
+      - kind: ServiceAccount
+        name: ''
+        version: v1
+      - kind: ValidatingWebhookConfiguration
+        name: validatingwebhookconfigurations.admissionregistration.k8s.io
+        version: v1beta1
+      - kind: MutatingWebhookConfiguration
+        name: mutatingwebhookconfigurations.admissionregistration.k8s.io
+        version: v1beta1
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: APIService
+        name: apiservices.apiregistration.k8s.io
+        version: v1
+      specDescriptors:
+      - description: Disables the use of hostNetwork by the webhook
+        displayName: DisableHostNetwork
+        path: disableHostNetwork
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: Enables the webhook component of cert-manager when set to true
+        displayName: EnableWebhook
+        path: enableWebhook
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: Appends the text to the image tag when it deploys cert-manager
+        displayName: ImagePostFix
+        path: imagePostFix
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: Sets the image registry to this when deploying cert-manager
+        displayName: ImageRegistry
+        path: imageRegistry
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The namespace where namespace scoped resources referenced by cert-manager clusterissuers must be placed
+        displayName: ResourceNamespace
+        path: resourceNamespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+  description: "**Important:** Do not install this operator directly. Only install this operator using the IBM Common Services Operator. For more information about installing this operator and other Common Services operators, see [Installer documentation](http://ibm.biz/cpcs_opinstall). Additionally, you can exit this panel and navigate to the IBM Common Services tile in OperatorHub to learn more about the operator. \n\n If you are using this operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator service. For more information about IBM Cloud Paks, see [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks).\n\n You can use the ibm-cert-manager-operator to install the IBM certificate manager service for the IBM Cloud Platform Common Services. You can use IBM certificate manager service to issue and manage x509 certificates from various sources, such as Let’s Encrypt and Hashicorp Vault, a simple signing key pair, or self-signed. It ensures certificates are valid and up to date and will renew certificates before they expire. \n\nFor more information about the available IBM Cloud Platform Common Services, see the [IBM Knowledge Center](http://ibm.biz/cpcsdocs). \n## Supported platforms \n\n Red Hat OpenShift Container Platform 4.3 or newer installed on one of the following platforms: \n\n- Linux x86_64 \n- Linux on Power (ppc64le) \n- Linux on IBM Z and LinuxONE \n## Prerequisites\n\n \n For the list of operator dependencies, see the IBM Knowledge Center [Common Services dependencies documentation](http://ibm.biz/cpcs_opdependencies). \n For the list of prerequisites for installing the operator, see the IBM Knowledge Center [Preparing to install services documentation](http://ibm.biz/cpcs_opinstprereq). \n## Documentation \n\n To install the operator with the IBM Common Services Operator follow the the installation and configuration instructions within the IBM Knowledge Center. \n- If you are using the operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak, for a list of IBM Cloud Paks, see [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks). \n- If you are using the operator with an IBM Containerized Software, see the IBM Cloud Platform Common Services Knowledge Center [Installer documentation](http://ibm.biz/cpcs_opinstall)."
+  displayName: IBM Cert Manager Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAK8AAACvCAMAAAC8TH5HAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAB1UExURQAAAJGS77CC4pCS75yM64uV8pSQ7puA85OV87OB4auF5Hyd+H2c936b9n6b94Ca9n+b9n+b9n+b9qOJ56SI55yM6qSI536b96aH5q2D45mN64OZ9ZWQ7oyU8XWg+6uG5oqg/p6L6m+k/ZuY+3mr/6qQ9LqM80D8C0oAAAAbdFJOUwA67R4KKxMBBP6ak6vZgVtJxG5ot+hQ7YDVkwC2C58AAAuSSURBVHja7ZyJerK8EoCDCSTKjoiIS13of/+XeGYm4NLKrvj1OYxt7aa8TiazJZGxSSaZZJJJJvmcSCn/Eq7Cz79DLJk0rb+kXdM9nz0m/4p2mZufz3lAZvEn1HsGye2J9128h7/Gezj8Nd7D3+I9/xu8SjWHrS76bfN8A+NsYxjowCvbPN+QSGB6kWi6QHteyQLPfx+wYsH2eHSthgu05lXMy/PceRcwxtnjdnts4mjLq5hBceVdcVsya71FMeov0JIXMuQwR+DoXX5EMgf0uz2GrDYbb8mrmE+4Z/NdvDCApN+jX3uFdrySqfW70wzFbFLwWtVNkXa8ONlIvfx9Dk0xSyvYq0NpxasYJ9o8emcUVCw6EjGvuUpLXgfVm9cP1fAZp1yyCKeGBf8pB96g9jUZ57c6s1vIIAUfjXqY9eFg1yiuKJnOECzeW+TJm0+rxRGGWfcP7/dld8bZwqcp/dJqIs9hrJIJ/JD2abV5j1StfJn1/pofo/Kx0ae1KfAO7/Vld7anfVpf28M5kKPDc9kYLRW4RDhIwYV/PozVUAF39Qre3BmrvsM04nisjHHyJlUjZEOefuBj8UIA81zHfGJ84BYeHAP9LKseP1r5LNnvOlHeXJgqRZbUPzT97PHvBVb48VCX09W54du2u3ZJwjD0It/gqmCue/yoolm4b7tQjmohh7cGAWzHC8x/qOFOZmBG4bbERDkQrVYyiGP7iPwPLGrgsAofYbePonEJ2CHxAuvjxEjLvfUj7J1BaP0irY3i888SA63l3alWgwKjbXueZztOSBoucOE33huIZdsWHChXRds72O069PyHhSEBDiOynbAEBiGreCGJKoa5zT8GVBzt4QNgXc+wbq4YvW+hSMkDYNa4EYihWqlYtmouSsYTo4XvgWezHKDcI+7xuPbMMp7JH0GEfhZGRMDIG5FRtLG1IGCNvTp/d9nFZhMx/DXYH/cgSBv6SscM+Tyf0P450Lw+iCmbOGAMonOeO/XlMyTjgAsfmWAN9Y53RFy0hDAovXBDSBFBVAIHDdUJ2lre3J6AVG9Hcln5NQyKCUcrd390g5/BtjpNR2KNGwTVpRDSmk6et6jwCv0ScVhpxopxl3DBIjzVjrYk5gVuEPAaw7UP+aFV+0ex5Aq8y/hTYhiE/UXjhibrlBUisUm8hmHwqujuH3IqQLA/0dT+Af8Q34hT8du3QXlR4nrdkxhJ0554nwAXhpvj+hLUo2u/zWoJM1aXy70ZP8e97APWJ+WGbN1AXNP8tedAasM96PLu4Ik2jhpHZLkqgdGM5TNjuKzNnhkiUmneH8CSCe9wpXV429HDlCu7GcV9JwemWoEbWr3rGZx2iMs5F4+T3S1p89DoYGvkUeLCKC67m+uBsVwVuGpI+QVohGtZ6rHrU+Cu/UaP/ps4KY3iWhlipwNwd4Arh1WLCIy4lpA/2yiF4XZ9ehgMuaRgt7r6FMWiC9DuL64YWtyCrQKuEOLe1iJsG+eO2W8eo+POdrvVtdULrgG0Dbg76xW1uCDcm5GCguzDAeNlz0qPqgfzGunJeAl4aOug6KYQ7l2WhI7DZEMqZ7L5a1uBZWTQF3/QVHvmUosOBX0ZVkbfkgNtDYCbDcDVsIKbQYCJBCY/gak7FHQh+bqiX7LwsnuYfr1gqUTCUsPWgsWdF1H2I1/ZoYBMSLs3o3/blyke+FRiEPE9c1Huq9dpV60GWQNmvybSIrCnee0SGIlDJzJfVzwrttTq7bfkUNCSzV71a19pScNOGHrmi9pWV/Uue6lXYpEcBFfgslSOPG0MBTASc/YK3455PEqvyYY5r0G4AeH6gWHqSCyVxQ2s9ksJw9B/ATBYVUy8fdRL6ZhhlPo1HpIyHelM38OmCuA6oWvzwTah69DTbiW6qxdMCdPdAIGLbrC8lyIimxHRgrhQcA+cdoqluxXc0u7qhcTGNBAYeKkB9CTASfJjVuTo7mvoRsO676Ci+LRanVbd91YgLggp2GI1/kpRq7MAXnuDjBhC8Qpkl3UepwIXgblseDQq2XBcUK8bru0hGgbni7ynzrMNs1xOuJDmNQMAsfAI2B0CjOaAvKuuK2aES8C8XU8Sn98H9SKw12/SwfwVzNyArOLOL1lxEpO37/lKFujlpW3UfTSZwpxaQCkXb+JVd3OAAg1xrQ4vFGzC0MDrbuvLSGtRiSVYuonjeNU5MxMWAVudZzct1azdLmUXzGZLV7BCySxG6Zrq4MsFXqv79A7WiLu1OwwLFgElr7VA3LQjLtZnCCx7+KNo7a4BuG3lhRmKWXQ0LME40Gbxsqt6BQH3arExZ+viCl67Ib1rGHFLQPIQL7JFnHTjRfUCb68whR1mXM3dttpjcWvIAS6uNCRxlmVxxypeCVJw3wjl0/LzmrfaVG4kBgFT6ge57wJ4M7OTfmlNS4j+McpB4G2rTfBGkhAwp2UcWfB2cw/FFogBKQvxrhtTLMnMZYJiFG4eeLM0zVLRg3dIzmJvAbfRgiXjS81rXfeBLIE3TTuVQneZeH8Fb4HXFQ0rcGKJcsNFXsRdduYdViSQBQNy0LCilaSIu+R3TeqP8KKLQAXXzjgw3hR5l3erFvoldOOVr9Cv5eK6v1tzXch0UZfLNGEPvGQi3fU7tMi1m45PgCtb4Nin974Lftmd9yUtJZ94q/NgUG9KvA9rWOjgwKATMTqv3mpcbcDgQxaLRbpYyp+89/5tLMF98GTAVZsP4LfpAuXRYnALBwof+0AxejR0EVVpO4ARbvpz96D1GV7FvNoJB4lNDLiQOKofIQSTicQcnzeq5ZUsxTpi8ctQJeVrJmNj8wbEWxHhYNxjXff8UiT1vww1Oq9R59Dgz1gGb5Kff5a62jA/4tD222Ml75J4zd+8uglmfcQB76s2nktsM2w2z8p2yamWG90eTNrd9ly/ALnAtlP8LO5a1FdSo9sv7h3cVvGqGHkXT9Sr+3ZcjO4faNNYUMErkHf2tIeuqBNhjc0bHXEDoVHBa20qeRm1liw1Mq9H29z68Ard+hs7f0BzWD/3S8g7q+TV3RohR8VVLqq34pgR2G8NL9O8alx3Rrvy7Cr3q2LkXTyPClrBY55JgPqCthFGVbxsgbxxRd2jxKCGTS/zpelW0beD8pB4NxVhVw7t2HSvj0m9lfUx5A/zzWw2q0yPHzYHjWEOuDXvWLnhAtL1Gah3XrWsImkL/WjAkoX7au+r00bQ7my+qFr4ekETpFvyUGsOKOAgZrNNZaE2InCx9XF/qVmFQwNGBVevs42n31K9+5oqFxw0GURc22UayXjBenHrY1Z7UJ/FpOCkRsFjWe+SNsLuef2xCm0QMfvwe60pxnGf5v7iNTR/xWZWb8GjWcOFgBtK3FLBM+uTCpatd5aigue1Pngs4yVcp8VphmT+YYuQGIhxm/Fu37w+j0mPBk4+BIy4ett8q52lGJTneJsbHwHGwx/FQYp2Q6wtogCWH8DNLtdt0S1Pi6RICx8JG1nFCluOV9yWLgrrjAI4HfVQNtYu5emw9ri0EyZGWpCNORYxvVuAGZeHgLIuEVZB5UnAqGLryfsLvDx31Gfa6czSSW+D7XRFVZgEyizlRfEm3yJFSaiM+HQ5Ee5ll3SNVgCczkvi+SJ5c+PMMtIV0BLu6RL32P8Lry8pcVHJcZoYlniDcCNJ49Xp+/uk5QK20PP0kLWYP8qsg2zuvl/VyAlQS1bQ7SnjfQ814O7WeF4jX/P/5l//fT2V77svePeNd/gFNam/FN/eZPd9io0B/ojOwMWVsA8/wO1RZvc/nOgTbqfi7okAfDbUe+KDjcVsPq9X81eJPK/g/So476kfWUG1S6vjmcIqYpGkGwT7r4t8FfffdIP7ajmdNlnC2Qto2fWNtixjudRr4a+VLF0uTa4vJF8XKuXbg/Hr33TjffKn3gp/kkkmmWSSSSaZZJJJJplkkkkmmWSS/yf5H6HANgUotAMHAAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - operator.ibm.com
+          resources:
+          - certmanagers
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - namespaces
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - cert-manager-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - operator.ibm.com
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - certmanager.k8s.io
+          resources:
+          - certificates
+          - certificaterequests
+          - orders
+          - challenges
+          - clusterissuers
+          - issuers
+          verbs:
+          - '*'
+        - apiGroups:
+          - certmanager.k8s.io
+          resources:
+          - certificates/status
+          - certificaterequests/status
+          - challenges/status
+          - orders/status
+          - issuers/status
+          - clusterissuers/status
+          - certificates/finalizers
+          - challenges/finalizers
+          - ingresses/finalizers
+          - orders/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - statefulsets
+          - daemonsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - create
+          - update
+          - patch
+        - apiGroups:
+          - admission.certmanager.k8s.io
+          resources:
+          - certificates
+          - clusterissuers
+          - issuers
+          - certificaterequests
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - restricted
+          - hostnetwork
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - '*'
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - '*'
+        - apiGroups:
+          - operator.open-cluster-management.io
+          resources:
+          - multiclusterhubs
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: ibm-cert-manager-operator
+      deployments:
+      - name: ibm-cert-manager-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: ibm-cert-manager-operator
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                productName: IBM Cloud Platform Common Services
+                productID: 068a62892a1e4db39641342e592daa25
+                productMetric: FREE
+              labels:
+                app.kubernetes.io/instance: ibm-cert-manager-operator
+                app.kubernetes.io/managed-by: ibm-cert-manager-operator
+                app.kubernetes.io/name: cert-manager
+                name: ibm-cert-manager-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: beta.kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - ppc64le
+                        - s390x
+              hostIPC: false
+              hostNetwork: false
+              hostPID: false
+              containers:
+              - args:
+                - --zap-level=1
+                command:
+                - ibm-cert-manager-operator
+                env:
+                - name: CONTROLLER_IMAGE_TAG_OR_SHA
+                  value: sha256:9f84ed2c290aa2d462c7856e65acbeb26b1b76d08db59c371f8dce684935c664
+                - name: WEBHOOK_IMAGE_TAG_OR_SHA
+                  value: sha256:993de0bac4d2cbf0dbf6726c18f76f1cc0a26f2ee199010ec16e7d6c8df287ed
+                - name: CAINJECTOR_IMAGE_TAG_OR_SHA
+                  value: sha256:b3fe797a450dfecdbb5de3483081486361b73c8c8c75960ea8ef1a9ce2757287
+                - name: ACMESOLVER_IMAGE_TAG_OR_SHA
+                  value: sha256:76a8614d1932c4dc5c665b9aa9aa98aa743fbb07c95711bf4006a9021e988709
+                - name: CONFIGMAP_WATCHER_IMAGE_TAG_OR_SHA
+                  value: sha256:0ae5434124351ee206a8ee9a8caa9355285055ce82581e26b1f594dc267bab3b
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: ibm-cert-manager-operator
+                image: quay.io/opencloudio/ibm-cert-manager-operator:latest
+                imagePullPolicy: Always
+                name: ibm-cert-manager-operator
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 300Mi
+                  requests:
+                    cpu: 10m
+                    memory: 50Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: true
+              serviceAccountName: ibm-cert-manager-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - Cert-Manager
+  - IBM
+  - Cloud
+  maintainers:
+  - email: swati.nair@ibm.com
+    name: Swati Shridhar Nair
+  - email: tthorpe@us.ibm.com
+    name: Robert T. Thorpe
+  maturity: alpha
+  provider:
+    name: IBM
+  replaces: ibm-cert-manager-operator.v3.7.0
+  version: 3.7.1

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.7.1/ibm-cert-manager-operator.v3.7.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.7.1/ibm-cert-manager-operator.v3.7.1.clusterserviceversion.yaml
@@ -89,6 +89,11 @@ metadata:
     createdAt: "2020-09-01T21:35:00Z"
     description: Operator for managing deployment of cert-manager service.
     support: IBM
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/os.linux: supported
   name: ibm-cert-manager-operator.v3.7.1
   namespace: placeholder
 spec:

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.7.1/issuer-crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.7.1/issuer-crd.yaml
@@ -1,0 +1,1981 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: issuers.certmanager.k8s.io
+  labels:
+    app.kubernetes.io/instance: ibm-cert-manager-operator
+    app.kubernetes.io/managed-by: ibm-cert-manager-operator
+    app.kubernetes.io/name: cert-manager
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IssuerSpec is the specification of an Issuer. This includes
+            any configuration required for the issuer.
+          properties:
+            acme:
+              description: ACMEIssuer contains the specification for an ACME issuer
+              properties:
+                dns01:
+                  description: 'DEPRECATED: DNS-01 config'
+                  properties:
+                    providers:
+                      items:
+                        description: ACMEIssuerDNS01Provider contains configuration
+                          for a DNS provider that can be used to solve ACME DNS01
+                          challenges.
+                        properties:
+                          acmedns:
+                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                              containing the configuration for ACME-DNS servers
+                            properties:
+                              accountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              host:
+                                type: string
+                            required:
+                            - accountSecretRef
+                            - host
+                            type: object
+                          akamai:
+                            description: ACMEIssuerDNS01ProviderAkamai is a structure
+                              containing the DNS configuration for Akamai DNS—Zone
+                              Record Management API
+                            properties:
+                              accessTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              serviceConsumerDomain:
+                                type: string
+                            required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                            type: object
+                          azuredns:
+                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                              containing the configuration for Azure DNS
+                            properties:
+                              clientID:
+                                type: string
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                                type: string
+                              hostedZoneName:
+                                type: string
+                              resourceGroupName:
+                                type: string
+                              subscriptionID:
+                                type: string
+                              tenantID:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecretSecretRef
+                            - resourceGroupName
+                            - subscriptionID
+                            - tenantID
+                            type: object
+                          clouddns:
+                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                              containing the DNS configuration for Google Cloud DNS
+                            properties:
+                              project:
+                                type: string
+                              serviceAccountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - project
+                            - serviceAccountSecretRef
+                            type: object
+                          cloudflare:
+                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                              containing the DNS configuration for Cloudflare
+                            properties:
+                              apiKeySecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              email:
+                                type: string
+                            required:
+                            - apiKeySecretRef
+                            - email
+                            type: object
+                          cnameStrategy:
+                            description: CNAMEStrategy configures how the DNS01 provider
+                              should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
+                            type: string
+                          digitalocean:
+                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                              structure containing the DNS configuration for DigitalOcean
+                              Domains
+                            properties:
+                              tokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - tokenSecretRef
+                            type: object
+                          name:
+                            description: Name is the name of the DNS provider, which
+                              should be used to reference this DNS provider configuration
+                              on Certificate resources.
+                            type: string
+                          rfc2136:
+                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                              containing the configuration for RFC2136 DNS
+                            properties:
+                              nameserver:
+                                description: 'The IP address of the DNS supporting
+                                  RFC2136. Required. Note: FQDN is not a valid value,
+                                  only IP.'
+                                type: string
+                              tsigAlgorithm:
+                                description: 'The TSIG Algorithm configured in the
+                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                  and ``tsigKeyName`` are defined. Supported values
+                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                  ``HMACSHA256`` or ``HMACSHA512``.'
+                                type: string
+                              tsigKeyName:
+                                description: The TSIG Key name configured in the DNS.
+                                  If ``tsigSecretSecretRef`` is defined, this field
+                                  is required.
+                                type: string
+                              tsigSecretSecretRef:
+                                description: The name of the secret containing the
+                                  TSIG value. If ``tsigKeyName`` is defined, this
+                                  field is required.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - nameserver
+                            type: object
+                          route53:
+                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                              containing the Route 53 configuration for AWS
+                            properties:
+                              accessKeyID:
+                                description: 'The AccessKeyID is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                type: string
+                              hostedZoneID:
+                                description: If set, the provider will manage only
+                                  this zone in Route53 and will not do an lookup using
+                                  the route53:ListHostedZonesByName api call.
+                                type: string
+                              region:
+                                description: Always set the region when using AccessKeyID
+                                  and SecretAccessKey
+                                type: string
+                              role:
+                                description: Role is a Role ARN which the Route53
+                                  provider will assume using either the explicit credentials
+                                  AccessKeyID/SecretAccessKey or the inferred credentials
+                                  from environment variables, shared credentials file
+                                  or AWS Instance metadata
+                                type: string
+                              secretAccessKeySecretRef:
+                                description: The SecretAccessKey is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - region
+                            type: object
+                          webhook:
+                            description: ACMEIssuerDNS01ProviderWebhook specifies
+                              configuration for a webhook DNS01 provider, including
+                              where to POST ChallengePayload resources.
+                            properties:
+                              config:
+                                description: Additional configuration that should
+                                  be passed to the webhook apiserver when challenges
+                                  are processed. This can contain arbitrary JSON data.
+                                  Secret values should not be specified in this stanza.
+                                  If secret values are needed (e.g. credentials for
+                                  a DNS service), you should use a SecretKeySelector
+                                  to reference a Secret resource. For details on the
+                                  schema of this field, consult the webhook provider
+                                  implementation's documentation.
+                                type: object
+                              groupName:
+                                description: The API group name that should be used
+                                  when POSTing ChallengePayload resources to the webhook
+                                  apiserver. This should be the same as the GroupName
+                                  specified in the webhook provider implementation.
+                                type: string
+                              solverName:
+                                description: The name of the solver to use, as defined
+                                  in the webhook provider implementation. This will
+                                  typically be the name of the provider, e.g. 'cloudflare'.
+                                type: string
+                            required:
+                            - groupName
+                            - solverName
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                  type: object
+                email:
+                  description: Email is the email for this account
+                  type: string
+                http01:
+                  description: 'DEPRECATED: HTTP-01 config'
+                  properties:
+                    serviceType:
+                      description: Optional service type for Kubernetes solver service
+                      type: string
+                  type: object
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  properties:
+                    key:
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  required:
+                  - name
+                  type: object
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+                solvers:
+                  description: Solvers is a list of challenge solvers that will be
+                    used to solve ACME challenges for the matching domains.
+                  items:
+                    properties:
+                      dns01:
+                        properties:
+                          acmedns:
+                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                              containing the configuration for ACME-DNS servers
+                            properties:
+                              accountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              host:
+                                type: string
+                            required:
+                            - accountSecretRef
+                            - host
+                            type: object
+                          akamai:
+                            description: ACMEIssuerDNS01ProviderAkamai is a structure
+                              containing the DNS configuration for Akamai DNS—Zone
+                              Record Management API
+                            properties:
+                              accessTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              serviceConsumerDomain:
+                                type: string
+                            required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                            type: object
+                          azuredns:
+                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                              containing the configuration for Azure DNS
+                            properties:
+                              clientID:
+                                type: string
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                                type: string
+                              hostedZoneName:
+                                type: string
+                              resourceGroupName:
+                                type: string
+                              subscriptionID:
+                                type: string
+                              tenantID:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecretSecretRef
+                            - resourceGroupName
+                            - subscriptionID
+                            - tenantID
+                            type: object
+                          clouddns:
+                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                              containing the DNS configuration for Google Cloud DNS
+                            properties:
+                              project:
+                                type: string
+                              serviceAccountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - project
+                            - serviceAccountSecretRef
+                            type: object
+                          cloudflare:
+                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                              containing the DNS configuration for Cloudflare
+                            properties:
+                              apiKeySecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              email:
+                                type: string
+                            required:
+                            - apiKeySecretRef
+                            - email
+                            type: object
+                          cnameStrategy:
+                            description: CNAMEStrategy configures how the DNS01 provider
+                              should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
+                            type: string
+                          digitalocean:
+                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                              structure containing the DNS configuration for DigitalOcean
+                              Domains
+                            properties:
+                              tokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - tokenSecretRef
+                            type: object
+                          rfc2136:
+                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                              containing the configuration for RFC2136 DNS
+                            properties:
+                              nameserver:
+                                description: 'The IP address of the DNS supporting
+                                  RFC2136. Required. Note: FQDN is not a valid value,
+                                  only IP.'
+                                type: string
+                              tsigAlgorithm:
+                                description: 'The TSIG Algorithm configured in the
+                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                  and ``tsigKeyName`` are defined. Supported values
+                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                  ``HMACSHA256`` or ``HMACSHA512``.'
+                                type: string
+                              tsigKeyName:
+                                description: The TSIG Key name configured in the DNS.
+                                  If ``tsigSecretSecretRef`` is defined, this field
+                                  is required.
+                                type: string
+                              tsigSecretSecretRef:
+                                description: The name of the secret containing the
+                                  TSIG value. If ``tsigKeyName`` is defined, this
+                                  field is required.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - nameserver
+                            type: object
+                          route53:
+                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                              containing the Route 53 configuration for AWS
+                            properties:
+                              accessKeyID:
+                                description: 'The AccessKeyID is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                type: string
+                              hostedZoneID:
+                                description: If set, the provider will manage only
+                                  this zone in Route53 and will not do an lookup using
+                                  the route53:ListHostedZonesByName api call.
+                                type: string
+                              region:
+                                description: Always set the region when using AccessKeyID
+                                  and SecretAccessKey
+                                type: string
+                              role:
+                                description: Role is a Role ARN which the Route53
+                                  provider will assume using either the explicit credentials
+                                  AccessKeyID/SecretAccessKey or the inferred credentials
+                                  from environment variables, shared credentials file
+                                  or AWS Instance metadata
+                                type: string
+                              secretAccessKeySecretRef:
+                                description: The SecretAccessKey is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - region
+                            type: object
+                          webhook:
+                            description: ACMEIssuerDNS01ProviderWebhook specifies
+                              configuration for a webhook DNS01 provider, including
+                              where to POST ChallengePayload resources.
+                            properties:
+                              config:
+                                description: Additional configuration that should
+                                  be passed to the webhook apiserver when challenges
+                                  are processed. This can contain arbitrary JSON data.
+                                  Secret values should not be specified in this stanza.
+                                  If secret values are needed (e.g. credentials for
+                                  a DNS service), you should use a SecretKeySelector
+                                  to reference a Secret resource. For details on the
+                                  schema of this field, consult the webhook provider
+                                  implementation's documentation.
+                                type: object
+                              groupName:
+                                description: The API group name that should be used
+                                  when POSTing ChallengePayload resources to the webhook
+                                  apiserver. This should be the same as the GroupName
+                                  specified in the webhook provider implementation.
+                                type: string
+                              solverName:
+                                description: The name of the solver to use, as defined
+                                  in the webhook provider implementation. This will
+                                  typically be the name of the provider, e.g. 'cloudflare'.
+                                type: string
+                            required:
+                            - groupName
+                            - solverName
+                            type: object
+                        type: object
+                      http01:
+                        description: ACMEChallengeSolverHTTP01 contains configuration
+                          detailing how to solve HTTP01 challenges within a Kubernetes
+                          cluster. Typically this is accomplished through creating
+                          'routes' of some description that configure ingress controllers
+                          to direct traffic to 'solver pods', which are responsible
+                          for responding to the ACME server's HTTP requests.
+                        properties:
+                          ingress:
+                            description: The ingress based HTTP01 challenge solver
+                              will solve challenges by creating or modifying Ingress
+                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                              to 'challenge solver' pods that are provisioned by cert-manager
+                              for each Challenge to be completed.
+                            properties:
+                              class:
+                                description: The ingress class to use when creating
+                                  Ingress resources to solve ACME challenges that
+                                  use this challenge solver. Only one of 'class' or
+                                  'name' may be specified.
+                                type: string
+                              name:
+                                description: The name of the ingress resource that
+                                  should have ACME challenge solving routes inserted
+                                  into it in order to solve HTTP01 challenges. This
+                                  is typically used in conjunction with ingress controllers
+                                  like ingress-gce, which maintains a 1:1 mapping
+                                  between external IPs and ingress resources.
+                                type: string
+                              podTemplate:
+                                description: Optional pod template used to configure
+                                  the ACME challenge solver pods used for HTTP01 challenges
+                                properties:
+                                  metadata:
+                                    description: ObjectMeta overrides for the pod
+                                      used to solve HTTP01 challenges. Only the 'labels'
+                                      and 'annotations' fields may be set. If labels
+                                      or annotations overlap with in-built values,
+                                      the values here will override the in-built values.
+                                    type: object
+                                  spec:
+                                    description: PodSpec defines overrides for the
+                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                      'affinity' and 'tolerations' fields are supported
+                                      currently. All other fields will be ignored.
+                                    properties:
+                                      affinity:
+                                        description: If specified, the pod's scheduling
+                                          constraints
+                                        properties:
+                                          nodeAffinity:
+                                            description: Describes node affinity scheduling
+                                              rules for the pod.
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node matches the
+                                                  corresponding matchExpressions;
+                                                  the node(s) with the highest sum
+                                                  are the most preferred.
+                                                items:
+                                                  description: An empty preferred
+                                                    scheduling term matches all objects
+                                                    with implicit weight 0 (i.e. it's
+                                                    a no-op). A null preferred scheduling
+                                                    term matches no objects (i.e.
+                                                    is also a no-op).
+                                                  properties:
+                                                    preference:
+                                                      description: A node selector
+                                                        term, associated with the
+                                                        corresponding weight.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    weight:
+                                                      description: Weight associated
+                                                        with matching the corresponding
+                                                        nodeSelectorTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to an update), the system
+                                                  may or may not try to eventually
+                                                  evict the pod from its node.
+                                                properties:
+                                                  nodeSelectorTerms:
+                                                    description: Required. A list
+                                                      of node selector terms. The
+                                                      terms are ORed.
+                                                    items:
+                                                      description: A null or empty
+                                                        node selector term matches
+                                                        no objects. The requirements
+                                                        of them are ANDed. The TopologySelectorTerm
+                                                        type implements a subset of
+                                                        the NodeSelectorTerm.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                required:
+                                                - nodeSelectorTerms
+                                                type: object
+                                            type: object
+                                          podAffinity:
+                                            description: Describes pod affinity scheduling
+                                              rules (e.g. co-locate this pod in the
+                                              same node, zone, etc. as some other
+                                              pod(s)).
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node has pods
+                                                  which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to a pod label update),
+                                                  the system may or may not try to
+                                                  eventually evict the pod from its
+                                                  node. When there are multiple elements,
+                                                  the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          podAntiAffinity:
+                                            description: Describes pod anti-affinity
+                                              scheduling rules (e.g. avoid putting
+                                              this pod in the same node, zone, etc.
+                                              as some other pod(s)).
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the anti-affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  anti-affinity expressions, etc.),
+                                                  compute a sum by iterating through
+                                                  the elements of this field and adding
+                                                  "weight" to the sum if the node
+                                                  has pods which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the anti-affinity
+                                                  requirements specified by this field
+                                                  are not met at scheduling time,
+                                                  the pod will not be scheduled onto
+                                                  the node. If the anti-affinity requirements
+                                                  specified by this field cease to
+                                                  be met at some point during pod
+                                                  execution (e.g. due to a pod label
+                                                  update), the system may or may not
+                                                  try to eventually evict the pod
+                                                  from its node. When there are multiple
+                                                  elements, the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                        type: object
+                                      nodeSelector:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'NodeSelector is a selector which
+                                          must be true for the pod to fit on a node.
+                                          Selector which must match a node''s labels
+                                          for the pod to be scheduled on that node.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                        type: object
+                                      tolerations:
+                                        description: If specified, the pod's tolerations.
+                                        items:
+                                          description: The pod this Toleration is
+                                            attached to tolerates any taint that matches
+                                            the triple <key,value,effect> using the
+                                            matching operator <operator>.
+                                          properties:
+                                            effect:
+                                              description: Effect indicates the taint
+                                                effect to match. Empty means match
+                                                all taint effects. When specified,
+                                                allowed values are NoSchedule, PreferNoSchedule
+                                                and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Key is the taint key that
+                                                the toleration applies to. Empty means
+                                                match all taint keys. If the key is
+                                                empty, operator must be Exists; this
+                                                combination means to match all values
+                                                and all keys.
+                                              type: string
+                                            operator:
+                                              description: Operator represents a key's
+                                                relationship to the value. Valid operators
+                                                are Exists and Equal. Defaults to
+                                                Equal. Exists is equivalent to wildcard
+                                                for value, so that a pod can tolerate
+                                                all taints of a particular category.
+                                              type: string
+                                            tolerationSeconds:
+                                              description: TolerationSeconds represents
+                                                the period of time the toleration
+                                                (which must be of effect NoExecute,
+                                                otherwise this field is ignored) tolerates
+                                                the taint. By default, it is not set,
+                                                which means tolerate the taint forever
+                                                (do not evict). Zero and negative
+                                                values will be treated as 0 (evict
+                                                immediately) by the system.
+                                              format: int64
+                                              type: integer
+                                            value:
+                                              description: Value is the taint value
+                                                the toleration matches to. If the
+                                                operator is Exists, the value should
+                                                be empty, otherwise just a regular
+                                                string.
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              serviceType:
+                                description: Optional service type for Kubernetes
+                                  solver service
+                                type: string
+                            type: object
+                        type: object
+                      selector:
+                        description: Selector selects a set of DNSNames on the Certificate
+                          resource that should be solved using this challenge solver.
+                        properties:
+                          dnsNames:
+                            description: List of DNSNames that this solver will be
+                              used to solve. If specified and a match is found, a
+                              dnsNames selector will take precedence over a dnsZones
+                              selector. If multiple solvers match with the same dnsNames
+                              value, the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          dnsZones:
+                            description: List of DNSZones that this solver will be
+                              used to solve. The most specific DNS zone match specified
+                              here will take precedence over other DNS zone matches,
+                              so a solver specifying sys.example.com will be selected
+                              over one specifying example.com for the domain www.sys.example.com.
+                              If multiple solvers match with the same dnsZones value,
+                              the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: A label selector that is used to refine the
+                              set of certificate's that this challenge solver will
+                              apply to.
+                            type: object
+                        type: object
+                    type: object
+                  type: array
+              required:
+              - privateKeySecretRef
+              - server
+              type: object
+            ca:
+              properties:
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+              required:
+              - secretName
+              type: object
+            selfSigned:
+              type: object
+            vault:
+              properties:
+                auth:
+                  description: Vault authentication
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+              required:
+              - auth
+              - path
+              - server
+              type: object
+            venafi:
+              description: VenafiIssuer describes issuer configuration details for
+                Venafi Cloud.
+              properties:
+                cloud:
+                  description: Cloud specifies the Venafi cloud configuration settings.
+                    Only one of TPP or Cloud may be specified.
+                  properties:
+                    apiTokenSecretRef:
+                      description: APITokenSecretRef is a secret key selector for
+                        the Venafi Cloud API token.
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for Venafi Cloud
+                      type: string
+                  required:
+                  - apiTokenSecretRef
+                  - url
+                  type: object
+                tpp:
+                  description: TPP specifies Trust Protection Platform configuration
+                    settings. Only one of TPP or Cloud may be specified.
+                  properties:
+                    caBundle:
+                      description: CABundle is a PEM encoded TLS certifiate to use
+                        to verify connections to the TPP instance. If specified, system
+                        roots will not be used and the issuing CA for the TPP instance
+                        must be verifiable using the provided root. If not specified,
+                        the connection will be verified using the cert-manager system
+                        root certificates.
+                      format: byte
+                      type: string
+                    credentialsRef:
+                      description: CredentialsRef is a reference to a Secret containing
+                        the username and password for the TPP server. The secret must
+                        contain two keys, 'username' and 'password'.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for the Venafi TPP instance
+                      type: string
+                  required:
+                  - credentialsRef
+                  - url
+                  type: object
+                zone:
+                  description: Zone is the Venafi Policy Zone to use for this issuer.
+                    All requests made to the Venafi platform will be restricted by
+                    the named zone policy. This field is required.
+                  type: string
+              required:
+              - zone
+              type: object
+          type: object
+        status:
+          description: IssuerStatus contains status information about an Issuer
+          properties:
+            acme:
+              properties:
+                lastRegisteredEmail:
+                  description: LastRegisteredEmail is the email associated with the
+                    latest registered ACME account, in order to track changes made
+                    to registered account associated with the  Issuer
+                  type: string
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+              type: object
+            conditions:
+              items:
+                description: IssuerCondition contains condition information for an
+                  Issuer.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.7.1/operator.ibm.com_certmanagers_crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.7.1/operator.ibm.com_certmanagers_crd.yaml
@@ -1,0 +1,69 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certmanagers.operator.ibm.com
+  labels:
+    app.kubernetes.io/instance: ibm-cert-manager-operator
+    app.kubernetes.io/managed-by: ibm-cert-manager-operator
+    app.kubernetes.io/name: cert-manager
+spec:
+  group: operator.ibm.com
+  names:
+    kind: CertManager
+    listKind: CertManagerList
+    plural: certmanagers
+    singular: certmanager
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: CertManager is the Schema for the certmanagers API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CertManagerSpec defines the desired state of CertManager
+          properties:
+            disableHostNetwork:
+              type: boolean
+            enableWebhook:
+              type: boolean
+            imagePostFix:
+              type: string
+            imageRegistry:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              type: string
+            resourceNamespace:
+              type: string
+            version:
+              type: string
+          type: object
+        status:
+          description: CertManagerStatus defines the observed state of CertManager
+          properties:
+            certManagerStatus:
+              description: It will be as "OK when all objects are created successfully
+              type: string
+          required:
+          - certManagerStatus
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ibm-cert-manager-operator/ibm-cert-manager-operator.package.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/ibm-cert-manager-operator.package.yaml
@@ -1,7 +1,7 @@
 channels:
-- currentCSV: ibm-cert-manager-operator.v3.7.0
+- currentCSV: ibm-cert-manager-operator.v3.7.1
   name: dev
-- currentCSV: ibm-cert-manager-operator.v3.6.3
+- currentCSV: ibm-cert-manager-operator.v3.7.0
   name: beta
 - currentCSV: ibm-cert-manager-operator.v3.6.3
   name: stable-v1

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 var (
-	Version = "3.7.0"
+	Version = "3.7.1"
 )


### PR DESCRIPTION
- Bump up CSV from 3.7.0 to 3.7.1
- Add labels in 3.7.1 CSV to support multiple architectures
- Add automated script to bump up CSVs
- Point dev channel to 3.7.1 and beta to 3.7.0