### PR TITLE
Update duration of root CA to 2 years

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml
@@ -12,10 +12,5 @@ spec:
   imageRegistry: quay.io/opencloudio
   version: "3.9.0"
   enableCertRefresh: true
-  refreshCertsBasedOnCA:
-  - certName: cs-ca-certificate
-    namespace: ibm-common-services
-  - certName: mongodb-root-ca-cert
-    namespace: ibm-common-services
 status:
   certManagerStatus: ''

--- a/deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_certmanager_cr.yaml
@@ -12,5 +12,7 @@ spec:
   imageRegistry: quay.io/opencloudio
   version: "3.9.0"
   enableCertRefresh: true
+  duration: 17520h0m0s
+  renewBefore: 720h0m0s
 status:
   certManagerStatus: ''

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.9.0/ibm-cert-manager-operator.v3.9.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.9.0/ibm-cert-manager-operator.v3.9.0.clusterserviceversion.yaml
@@ -20,7 +20,8 @@ metadata:
             "disableHostNetwork": true,
             "enableWebhook": true,
             "imageRegistry": "quay.io/opencloudio",
-            "version": "3.9.0"
+            "version": "3.9.0",
+            "enableCertRefresh": true
           },
           "status": {
             "certManagerStatus": ""
@@ -59,7 +60,9 @@ metadata:
               "kind": "Issuer"
             },
             "commonName": "cs-ca-certificate",
-            "isCA": true
+            "isCA": true,
+            "duration": "17520h",
+            "renewBefore": "720h"
           }
         },
         {

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.9.0/ibm-cert-manager-operator.v3.9.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.9.0/ibm-cert-manager-operator.v3.9.0.clusterserviceversion.yaml
@@ -61,8 +61,8 @@ metadata:
             },
             "commonName": "cs-ca-certificate",
             "isCA": true,
-            "duration": "17520h",
-            "renewBefore": "720h"
+            "duration": "17520h0m0s",
+            "renewBefore": "720h0m0s"
           }
         },
         {

--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -282,6 +282,9 @@ var CSCAIssuerLabelMap = map[string]string{
 //CSCAIssuerName is the name of the CS CA Issuer
 const CSCAIssuerName = "cs-ca-issuer"
 
+//CSCACertName is the name of the CS CA certificate
+const CSCACertName = "cs-ca-certificate"
+
 //CSCASecretName is the name of the CA certificate secret
 const CSCASecretName = "cs-ca-certificate-secret"
 
@@ -308,11 +311,11 @@ const DefaultEnableCertRefresh = true
 var DefaultCAList = []operatorv1alpha1.CACertificate{
 	{
 		CertName:  "cs-ca-certificate",
-		Namespace: "ibm-common-services",
+		Namespace: DeployNamespace,
 	},
 	{
 		CertName:  "mongodb-root-ca-cert",
-		Namespace: "ibm-common-services",
+		Namespace: DeployNamespace,
 	},
 }
 


### PR DESCRIPTION
Update the duration of root CA to 2 years
Replace hard coded namespace `ibm-common-services` with the deploy namespace