### PR TITLE
changed refresh leaf certificate logic to work with SaaS

### DIFF
--- a/pkg/controller/certificaterefresh/certificaterefresh_controller.go
+++ b/pkg/controller/certificaterefresh/certificaterefresh_controller.go
@@ -146,7 +146,6 @@ func (r *ReconcileCertificateRefresh) Reconcile(request reconcile.Request) (reco
 	}
 
 	//set the list of CAs that need their leaf certs refreshed
-	// listOfCAs = res.DefaultCAList
 	listOfCAs = r.buildDefaultCAList()
 	listOfCAs = append(listOfCAs, instance.Spec.RefreshCertsBasedOnCA...)
 

--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -19,7 +19,6 @@ package resources
 import (
 	"os"
 
-	operatorv1alpha1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/operator/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -308,16 +307,17 @@ var RhacmGVK = schema.GroupVersionKind{
 const DefaultEnableCertRefresh = true
 
 // DefaultCAList is the default CA for which the leaf certs need to be refreshed
-var DefaultCAList = []operatorv1alpha1.CACertificate{
-	{
-		CertName:  "cs-ca-certificate",
-		Namespace: DeployNamespace,
-	},
-	{
-		CertName:  "mongodb-root-ca-cert",
-		Namespace: DeployNamespace,
-	},
-}
+// var DefaultCAList = []operatorv1alpha1.CACertificate{
+// 	{
+// 		CertName:  "cs-ca-certificate",
+// 		Namespace: DeployNamespace,
+// 	},
+// 	{
+// 		CertName:  "mongodb-root-ca-cert",
+// 		Namespace: DeployNamespace,
+// 	},
+// }
+var DefaultCANames = []string{"cs-ca-certificate", "mongodb-root-ca-cert"}
 
 // CertManager instance name
 const CertManagerInstanceName = "default"

--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -321,3 +321,7 @@ var DefaultCANames = []string{"cs-ca-certificate", "mongodb-root-ca-cert"}
 
 // CertManager instance name
 const CertManagerInstanceName = "default"
+
+const OdlmDeploymentName = "operand-deployment-lifecycle-manager"
+
+const ProductName = "IBM Cloud Pak Foundational Services"

--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -306,22 +306,14 @@ var RhacmGVK = schema.GroupVersionKind{
 // DefaultEnableCertRefresh is set to true
 const DefaultEnableCertRefresh = true
 
-// DefaultCAList is the default CA for which the leaf certs need to be refreshed
-// var DefaultCAList = []operatorv1alpha1.CACertificate{
-// 	{
-// 		CertName:  "cs-ca-certificate",
-// 		Namespace: DeployNamespace,
-// 	},
-// 	{
-// 		CertName:  "mongodb-root-ca-cert",
-// 		Namespace: DeployNamespace,
-// 	},
-// }
+// DefaultCANames is the default CA names for which the leaf certs need to be refreshed
 var DefaultCANames = []string{"cs-ca-certificate", "mongodb-root-ca-cert"}
 
 // CertManager instance name
 const CertManagerInstanceName = "default"
 
+// OdlmDeploymentName is the deployment name of ODLM
 const OdlmDeploymentName = "operand-deployment-lifecycle-manager"
 
+// ProductName is the name of Common Services
 const ProductName = "IBM Cloud Pak Foundational Services"


### PR DESCRIPTION
refresh logic now builds the default list of certificates whenever certificates are being refreshed. This default list is based on the certificates Common Services requires to function properly. Uses ODLM deployments as a guide to find where each instance of Common Services is deployed. This logic should also work for on-prem, singleton CS deployment