### PR TITLE
feat: Set v1alpha1 objects as the owner of v1 objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ build: build-amd64 build-ppc64le build-s390x
 
 build-amd64:
 	@echo "Building the ${IMG} amd64 binary..."
-	@GOARCH=amd64 common/scripts/gobuild.sh build/_output/bin/$(IMG) ./cmd/manager
+	@GOOS=linux GOARCH=amd64 common/scripts/gobuild.sh build/_output/bin/$(IMG) ./cmd/manager
 
 build-ppc64le:
 	@echo "Building the ${IMG} ppc64le binary..."

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -4,4 +4,4 @@
 # to for triaging and handling of incoming issues.
 #
 
-morvencao
+bitscuit

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/acme.cert-manager.io_challenges_crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/acme.cert-manager.io_challenges_crd.yaml
@@ -1,0 +1,3880 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: challenges.acme.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    # Generated labels
+    app.kubernetes.io/version: "v1.5.1"
+spec:
+  group: acme.cert-manager.io
+  names:
+    kind: Challenge
+    listKind: ChallengeList
+    plural: challenges
+    singular: challenge
+    categories:
+      - cert-manager
+      - cert-manager-acme
+  scope: Namespaced
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhook:
+      # We don't actually support `v1beta1` but is listed here as it is a
+      # required value for [Kubernetes v1.16](kubernetes/kubernetes#82023). The
+      # API server reads the supported versions in order, so _should always_
+      # attempt a `v1` request which is understood by the cert-manager webhook.
+      # Any `v1beta1` request will return an error and fail closed for that
+      # resource (the whole object request is rejected).
+      # When we no longer support v1.16 we can remove `v1beta1` from this list.
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        #
+        service:
+          name: 'cert-manager-webhook'
+          namespace: "cert-manager"
+          path: /convert
+          #
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.dnsName
+          name: Domain
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: Challenge is a type to represent a Challenge request with an ACME server
+          type: object
+          required:
+            - metadata
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - authzURL
+                - dnsName
+                - issuerRef
+                - key
+                - solver
+                - token
+                - type
+                - url
+              properties:
+                authzURL:
+                  description: AuthzURL is the URL to the ACME Authorization resource that this challenge is a part of.
+                  type: string
+                dnsName:
+                  description: DNSName is the identifier that this challenge is for, e.g. example.com. If the requested DNSName is a 'wildcard', this field MUST be set to the non-wildcard domain, e.g. for `*.example.com`, it must be `example.com`.
+                  type: string
+                issuerRef:
+                  description: IssuerRef references a properly configured ACME-type Issuer which should be used to create this Challenge. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Challenge will be marked as failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                key:
+                  description: 'Key is the ACME challenge key for this challenge For HTTP01 challenges, this is the value that must be responded with to complete the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key from acme server for challenge>`. For DNS01 challenges, this is the base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key from acme server for challenge>` text that must be set as the TXT record content.'
+                  type: string
+                solver:
+                  description: Solver contains the domain solving configuration that should be used to solve this challenge resource.
+                  type: object
+                  properties:
+                    dns01:
+                      description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                      type: object
+                      properties:
+                        acmedns:
+                          description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - accountSecretRef
+                            - host
+                          properties:
+                            accountSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            host:
+                              type: string
+                        akamai:
+                          description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                          properties:
+                            accessTokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            clientSecretSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            clientTokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceConsumerDomain:
+                              type: string
+                        azuredns:
+                          description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - resourceGroupName
+                            - subscriptionID
+                          properties:
+                            clientID:
+                              description: if both this and ClientSecret are left unset MSI will be used
+                              type: string
+                            clientSecretSecretRef:
+                              description: if both this and ClientID are left unset MSI will be used
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            environment:
+                              type: string
+                              enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                            hostedZoneName:
+                              type: string
+                            resourceGroupName:
+                              type: string
+                            subscriptionID:
+                              type: string
+                            tenantID:
+                              description: when specifying ClientID and ClientSecret then this field is also needed
+                              type: string
+                        clouddns:
+                          description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - project
+                          properties:
+                            hostedZoneName:
+                              description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                              type: string
+                            project:
+                              type: string
+                            serviceAccountSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        cloudflare:
+                          description: Use the Cloudflare API to manage DNS01 challenge records.
+                          type: object
+                          properties:
+                            apiKeySecretRef:
+                              description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            apiTokenSecretRef:
+                              description: API token used to authenticate with Cloudflare.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            email:
+                              description: Email of the account, only required when using API key based authentication.
+                              type: string
+                        cnameStrategy:
+                          description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                          type: string
+                          enum:
+                            - None
+                            - Follow
+                        digitalocean:
+                          description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - tokenSecretRef
+                          properties:
+                            tokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        rfc2136:
+                          description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - nameserver
+                          properties:
+                            nameserver:
+                              description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                              type: string
+                            tsigAlgorithm:
+                              description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                              type: string
+                            tsigKeyName:
+                              description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                              type: string
+                            tsigSecretSecretRef:
+                              description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        route53:
+                          description: Use the AWS Route53 API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - region
+                          properties:
+                            accessKeyID:
+                              description: 'The AccessKeyID is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                              type: string
+                            hostedZoneID:
+                              description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                              type: string
+                            region:
+                              description: Always set the region when using AccessKeyID and SecretAccessKey
+                              type: string
+                            role:
+                              description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                              type: string
+                            secretAccessKeySecretRef:
+                              description: The SecretAccessKey is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        webhook:
+                          description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - groupName
+                            - solverName
+                          properties:
+                            config:
+                              description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                              x-kubernetes-preserve-unknown-fields: true
+                            groupName:
+                              description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                              type: string
+                            solverName:
+                              description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                              type: string
+                    http01:
+                      description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                      type: object
+                      properties:
+                        gatewayHTTPRoute:
+                          description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                          type: object
+                          properties:
+                            labels:
+                              description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                              type: object
+                              additionalProperties:
+                                type: string
+                            serviceType:
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                              type: string
+                        ingress:
+                          description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                          type: object
+                          properties:
+                            class:
+                              description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                              type: string
+                            ingressTemplate:
+                              description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges
+                              type: object
+                              properties:
+                                metadata:
+                                  description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                            name:
+                              description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                              type: string
+                            podTemplate:
+                              description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
+                              type: object
+                              properties:
+                                metadata:
+                                  description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                spec:
+                                  description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                  type: object
+                                  properties:
+                                    affinity:
+                                      description: If specified, the pod's scheduling constraints
+                                      type: object
+                                      properties:
+                                        nodeAffinity:
+                                          description: Describes node affinity scheduling rules for the pod.
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                type: object
+                                                required:
+                                                  - preference
+                                                  - weight
+                                                properties:
+                                                  preference:
+                                                    description: A node selector term, associated with the corresponding weight.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                  weight:
+                                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                              type: object
+                                              required:
+                                                - nodeSelectorTerms
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  description: Required. A list of node selector terms. The terms are ORed.
+                                                  type: array
+                                                  items:
+                                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                        podAffinity:
+                                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query over a set of resources, in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaceSelector:
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              type: array
+                                              items:
+                                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over a set of resources, in this case pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaceSelector:
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaces:
+                                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                    type: string
+                                        podAntiAffinity:
+                                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query over a set of resources, in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaceSelector:
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              type: array
+                                              items:
+                                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over a set of resources, in this case pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaceSelector:
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaces:
+                                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                    type: string
+                                    nodeSelector:
+                                      description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    priorityClassName:
+                                      description: If specified, the pod's priorityClassName.
+                                      type: string
+                                    serviceAccountName:
+                                      description: If specified, the pod's service account
+                                      type: string
+                                    tolerations:
+                                      description: If specified, the pod's tolerations.
+                                      type: array
+                                      items:
+                                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                        type: object
+                                        properties:
+                                          effect:
+                                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                            type: integer
+                                            format: int64
+                                          value:
+                                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                            type: string
+                            serviceType:
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                              type: string
+                    selector:
+                      description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                      type: object
+                      properties:
+                        dnsNames:
+                          description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                          type: array
+                          items:
+                            type: string
+                        dnsZones:
+                          description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                          type: array
+                          items:
+                            type: string
+                        matchLabels:
+                          description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                          type: object
+                          additionalProperties:
+                            type: string
+                token:
+                  description: Token is the ACME challenge token for this challenge. This is the raw value returned from the ACME server.
+                  type: string
+                type:
+                  description: Type is the type of ACME challenge this resource represents. One of "http-01" or "dns-01".
+                  type: string
+                  enum:
+                    - http-01
+                    - dns-01
+                url:
+                  description: URL is the URL of the ACME Challenge resource for this challenge. This can be used to lookup details about the status of this challenge.
+                  type: string
+                wildcard:
+                  description: Wildcard will be true if this challenge is for a wildcard identifier, for example '*.example.com'.
+                  type: boolean
+            status:
+              type: object
+              properties:
+                presented:
+                  description: Presented will be set to true if the challenge values for this challenge are currently 'presented'. This *does not* imply the self check is passing. Only that the values have been 'submitted' for the appropriate challenge mechanism (i.e. the DNS01 TXT record has been presented, or the HTTP01 configuration has been configured).
+                  type: boolean
+                processing:
+                  description: Processing is used to denote whether this challenge should be processed or not. This field will only be set to true by the 'scheduling' component. It will only be set to false by the 'challenges' controller, after the challenge has reached a final state or timed out. If this field is set to false, the challenge controller will not take any more action.
+                  type: boolean
+                reason:
+                  description: Reason contains human readable information on why the Challenge is in the current state.
+                  type: string
+                state:
+                  description: State contains the current 'state' of the challenge. If not set, the state of the challenge is unknown.
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.dnsName
+          name: Domain
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          description: Challenge is a type to represent a Challenge request with an ACME server
+          type: object
+          required:
+            - metadata
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - authzURL
+                - dnsName
+                - issuerRef
+                - key
+                - solver
+                - token
+                - type
+                - url
+              properties:
+                authzURL:
+                  description: AuthzURL is the URL to the ACME Authorization resource that this challenge is a part of.
+                  type: string
+                dnsName:
+                  description: DNSName is the identifier that this challenge is for, e.g. example.com. If the requested DNSName is a 'wildcard', this field MUST be set to the non-wildcard domain, e.g. for `*.example.com`, it must be `example.com`.
+                  type: string
+                issuerRef:
+                  description: IssuerRef references a properly configured ACME-type Issuer which should be used to create this Challenge. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Challenge will be marked as failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                key:
+                  description: 'Key is the ACME challenge key for this challenge For HTTP01 challenges, this is the value that must be responded with to complete the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key from acme server for challenge>`. For DNS01 challenges, this is the base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key from acme server for challenge>` text that must be set as the TXT record content.'
+                  type: string
+                solver:
+                  description: Solver contains the domain solving configuration that should be used to solve this challenge resource.
+                  type: object
+                  properties:
+                    dns01:
+                      description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                      type: object
+                      properties:
+                        acmedns:
+                          description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - accountSecretRef
+                            - host
+                          properties:
+                            accountSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            host:
+                              type: string
+                        akamai:
+                          description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                          properties:
+                            accessTokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            clientSecretSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            clientTokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceConsumerDomain:
+                              type: string
+                        azuredns:
+                          description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - resourceGroupName
+                            - subscriptionID
+                          properties:
+                            clientID:
+                              description: if both this and ClientSecret are left unset MSI will be used
+                              type: string
+                            clientSecretSecretRef:
+                              description: if both this and ClientID are left unset MSI will be used
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            environment:
+                              type: string
+                              enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                            hostedZoneName:
+                              type: string
+                            resourceGroupName:
+                              type: string
+                            subscriptionID:
+                              type: string
+                            tenantID:
+                              description: when specifying ClientID and ClientSecret then this field is also needed
+                              type: string
+                        clouddns:
+                          description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - project
+                          properties:
+                            hostedZoneName:
+                              description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                              type: string
+                            project:
+                              type: string
+                            serviceAccountSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        cloudflare:
+                          description: Use the Cloudflare API to manage DNS01 challenge records.
+                          type: object
+                          properties:
+                            apiKeySecretRef:
+                              description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            apiTokenSecretRef:
+                              description: API token used to authenticate with Cloudflare.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            email:
+                              description: Email of the account, only required when using API key based authentication.
+                              type: string
+                        cnameStrategy:
+                          description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                          type: string
+                          enum:
+                            - None
+                            - Follow
+                        digitalocean:
+                          description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - tokenSecretRef
+                          properties:
+                            tokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        rfc2136:
+                          description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - nameserver
+                          properties:
+                            nameserver:
+                              description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                              type: string
+                            tsigAlgorithm:
+                              description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                              type: string
+                            tsigKeyName:
+                              description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                              type: string
+                            tsigSecretSecretRef:
+                              description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        route53:
+                          description: Use the AWS Route53 API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - region
+                          properties:
+                            accessKeyID:
+                              description: 'The AccessKeyID is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                              type: string
+                            hostedZoneID:
+                              description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                              type: string
+                            region:
+                              description: Always set the region when using AccessKeyID and SecretAccessKey
+                              type: string
+                            role:
+                              description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                              type: string
+                            secretAccessKeySecretRef:
+                              description: The SecretAccessKey is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        webhook:
+                          description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - groupName
+                            - solverName
+                          properties:
+                            config:
+                              description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                              x-kubernetes-preserve-unknown-fields: true
+                            groupName:
+                              description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                              type: string
+                            solverName:
+                              description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                              type: string
+                    http01:
+                      description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                      type: object
+                      properties:
+                        gatewayHTTPRoute:
+                          description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                          type: object
+                          properties:
+                            labels:
+                              description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                              type: object
+                              additionalProperties:
+                                type: string
+                            serviceType:
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP.
+                              type: string
+                        ingress:
+                          description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                          type: object
+                          properties:
+                            class:
+                              description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                              type: string
+                            ingressTemplate:
+                              description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges
+                              type: object
+                              properties:
+                                metadata:
+                                  description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                            name:
+                              description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                              type: string
+                            podTemplate:
+                              description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
+                              type: object
+                              properties:
+                                metadata:
+                                  description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                spec:
+                                  description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                  type: object
+                                  properties:
+                                    affinity:
+                                      description: If specified, the pod's scheduling constraints
+                                      type: object
+                                      properties:
+                                        nodeAffinity:
+                                          description: Describes node affinity scheduling rules for the pod.
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                type: object
+                                                required:
+                                                  - preference
+                                                  - weight
+                                                properties:
+                                                  preference:
+                                                    description: A node selector term, associated with the corresponding weight.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                  weight:
+                                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                              type: object
+                                              required:
+                                                - nodeSelectorTerms
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  description: Required. A list of node selector terms. The terms are ORed.
+                                                  type: array
+                                                  items:
+                                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                        podAffinity:
+                                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query over a set of resources, in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaceSelector:
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              type: array
+                                              items:
+                                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over a set of resources, in this case pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaceSelector:
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaces:
+                                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                    type: string
+                                        podAntiAffinity:
+                                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query over a set of resources, in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaceSelector:
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              type: array
+                                              items:
+                                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over a set of resources, in this case pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaceSelector:
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaces:
+                                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                    type: string
+                                    nodeSelector:
+                                      description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    priorityClassName:
+                                      description: If specified, the pod's priorityClassName.
+                                      type: string
+                                    serviceAccountName:
+                                      description: If specified, the pod's service account
+                                      type: string
+                                    tolerations:
+                                      description: If specified, the pod's tolerations.
+                                      type: array
+                                      items:
+                                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                        type: object
+                                        properties:
+                                          effect:
+                                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                            type: integer
+                                            format: int64
+                                          value:
+                                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                            type: string
+                            serviceType:
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                              type: string
+                    selector:
+                      description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                      type: object
+                      properties:
+                        dnsNames:
+                          description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                          type: array
+                          items:
+                            type: string
+                        dnsZones:
+                          description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                          type: array
+                          items:
+                            type: string
+                        matchLabels:
+                          description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                          type: object
+                          additionalProperties:
+                            type: string
+                token:
+                  description: Token is the ACME challenge token for this challenge. This is the raw value returned from the ACME server.
+                  type: string
+                type:
+                  description: Type is the type of ACME challenge this resource represents. One of "http-01" or "dns-01".
+                  type: string
+                  enum:
+                    - http-01
+                    - dns-01
+                url:
+                  description: URL is the URL of the ACME Challenge resource for this challenge. This can be used to lookup details about the status of this challenge.
+                  type: string
+                wildcard:
+                  description: Wildcard will be true if this challenge is for a wildcard identifier, for example '*.example.com'.
+                  type: boolean
+            status:
+              type: object
+              properties:
+                presented:
+                  description: Presented will be set to true if the challenge values for this challenge are currently 'presented'. This *does not* imply the self check is passing. Only that the values have been 'submitted' for the appropriate challenge mechanism (i.e. the DNS01 TXT record has been presented, or the HTTP01 configuration has been configured).
+                  type: boolean
+                processing:
+                  description: Processing is used to denote whether this challenge should be processed or not. This field will only be set to true by the 'scheduling' component. It will only be set to false by the 'challenges' controller, after the challenge has reached a final state or timed out. If this field is set to false, the challenge controller will not take any more action.
+                  type: boolean
+                reason:
+                  description: Reason contains human readable information on why the Challenge is in the current state.
+                  type: string
+                state:
+                  description: State contains the current 'state' of the challenge. If not set, the state of the challenge is unknown.
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.dnsName
+          name: Domain
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Challenge is a type to represent a Challenge request with an ACME server
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - authorizationURL
+                - dnsName
+                - issuerRef
+                - key
+                - solver
+                - token
+                - type
+                - url
+              properties:
+                authorizationURL:
+                  description: The URL to the ACME Authorization resource that this challenge is a part of.
+                  type: string
+                dnsName:
+                  description: dnsName is the identifier that this challenge is for, e.g. example.com. If the requested DNSName is a 'wildcard', this field MUST be set to the non-wildcard domain, e.g. for `*.example.com`, it must be `example.com`.
+                  type: string
+                issuerRef:
+                  description: References a properly configured ACME-type Issuer which should be used to create this Challenge. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Challenge will be marked as failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                key:
+                  description: 'The ACME challenge key for this challenge For HTTP01 challenges, this is the value that must be responded with to complete the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key from acme server for challenge>`. For DNS01 challenges, this is the base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key from acme server for challenge>` text that must be set as the TXT record content.'
+                  type: string
+                solver:
+                  description: Contains the domain solving configuration that should be used to solve this challenge resource.
+                  type: object
+                  properties:
+                    dns01:
+                      description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                      type: object
+                      properties:
+                        acmeDNS:
+                          description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - accountSecretRef
+                            - host
+                          properties:
+                            accountSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            host:
+                              type: string
+                        akamai:
+                          description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                          properties:
+                            accessTokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            clientSecretSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            clientTokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceConsumerDomain:
+                              type: string
+                        azureDNS:
+                          description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - resourceGroupName
+                            - subscriptionID
+                          properties:
+                            clientID:
+                              description: if both this and ClientSecret are left unset MSI will be used
+                              type: string
+                            clientSecretSecretRef:
+                              description: if both this and ClientID are left unset MSI will be used
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            environment:
+                              type: string
+                              enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                            hostedZoneName:
+                              type: string
+                            resourceGroupName:
+                              type: string
+                            subscriptionID:
+                              type: string
+                            tenantID:
+                              description: when specifying ClientID and ClientSecret then this field is also needed
+                              type: string
+                        cloudDNS:
+                          description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - project
+                          properties:
+                            hostedZoneName:
+                              description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                              type: string
+                            project:
+                              type: string
+                            serviceAccountSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        cloudflare:
+                          description: Use the Cloudflare API to manage DNS01 challenge records.
+                          type: object
+                          properties:
+                            apiKeySecretRef:
+                              description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            apiTokenSecretRef:
+                              description: API token used to authenticate with Cloudflare.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            email:
+                              description: Email of the account, only required when using API key based authentication.
+                              type: string
+                        cnameStrategy:
+                          description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                          type: string
+                          enum:
+                            - None
+                            - Follow
+                        digitalocean:
+                          description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - tokenSecretRef
+                          properties:
+                            tokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        rfc2136:
+                          description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - nameserver
+                          properties:
+                            nameserver:
+                              description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                              type: string
+                            tsigAlgorithm:
+                              description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                              type: string
+                            tsigKeyName:
+                              description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                              type: string
+                            tsigSecretSecretRef:
+                              description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        route53:
+                          description: Use the AWS Route53 API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - region
+                          properties:
+                            accessKeyID:
+                              description: 'The AccessKeyID is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                              type: string
+                            hostedZoneID:
+                              description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                              type: string
+                            region:
+                              description: Always set the region when using AccessKeyID and SecretAccessKey
+                              type: string
+                            role:
+                              description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                              type: string
+                            secretAccessKeySecretRef:
+                              description: The SecretAccessKey is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        webhook:
+                          description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - groupName
+                            - solverName
+                          properties:
+                            config:
+                              description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                              x-kubernetes-preserve-unknown-fields: true
+                            groupName:
+                              description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                              type: string
+                            solverName:
+                              description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                              type: string
+                    http01:
+                      description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                      type: object
+                      properties:
+                        gatewayHTTPRoute:
+                          description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                          type: object
+                          properties:
+                            labels:
+                              description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                              type: object
+                              additionalProperties:
+                                type: string
+                            serviceType:
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                              type: string
+                        ingress:
+                          description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                          type: object
+                          properties:
+                            class:
+                              description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                              type: string
+                            ingressTemplate:
+                              description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.
+                              type: object
+                              properties:
+                                metadata:
+                                  description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                            name:
+                              description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                              type: string
+                            podTemplate:
+                              description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges
+                              type: object
+                              properties:
+                                metadata:
+                                  description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                spec:
+                                  description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                  type: object
+                                  properties:
+                                    affinity:
+                                      description: If specified, the pod's scheduling constraints
+                                      type: object
+                                      properties:
+                                        nodeAffinity:
+                                          description: Describes node affinity scheduling rules for the pod.
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                type: object
+                                                required:
+                                                  - preference
+                                                  - weight
+                                                properties:
+                                                  preference:
+                                                    description: A node selector term, associated with the corresponding weight.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                  weight:
+                                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                              type: object
+                                              required:
+                                                - nodeSelectorTerms
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  description: Required. A list of node selector terms. The terms are ORed.
+                                                  type: array
+                                                  items:
+                                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                        podAffinity:
+                                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query over a set of resources, in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaceSelector:
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              type: array
+                                              items:
+                                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over a set of resources, in this case pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaceSelector:
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaces:
+                                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                    type: string
+                                        podAntiAffinity:
+                                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query over a set of resources, in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaceSelector:
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              type: array
+                                              items:
+                                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over a set of resources, in this case pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaceSelector:
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaces:
+                                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                    type: string
+                                    nodeSelector:
+                                      description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    priorityClassName:
+                                      description: If specified, the pod's priorityClassName.
+                                      type: string
+                                    serviceAccountName:
+                                      description: If specified, the pod's service account
+                                      type: string
+                                    tolerations:
+                                      description: If specified, the pod's tolerations.
+                                      type: array
+                                      items:
+                                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                        type: object
+                                        properties:
+                                          effect:
+                                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                            type: integer
+                                            format: int64
+                                          value:
+                                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                            type: string
+                            serviceType:
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                              type: string
+                    selector:
+                      description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                      type: object
+                      properties:
+                        dnsNames:
+                          description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                          type: array
+                          items:
+                            type: string
+                        dnsZones:
+                          description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                          type: array
+                          items:
+                            type: string
+                        matchLabels:
+                          description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                          type: object
+                          additionalProperties:
+                            type: string
+                token:
+                  description: The ACME challenge token for this challenge. This is the raw value returned from the ACME server.
+                  type: string
+                type:
+                  description: The type of ACME challenge this resource represents. One of "HTTP-01" or "DNS-01".
+                  type: string
+                  enum:
+                    - HTTP-01
+                    - DNS-01
+                url:
+                  description: The URL of the ACME Challenge resource for this challenge. This can be used to lookup details about the status of this challenge.
+                  type: string
+                wildcard:
+                  description: wildcard will be true if this challenge is for a wildcard identifier, for example '*.example.com'.
+                  type: boolean
+            status:
+              type: object
+              properties:
+                presented:
+                  description: presented will be set to true if the challenge values for this challenge are currently 'presented'. This *does not* imply the self check is passing. Only that the values have been 'submitted' for the appropriate challenge mechanism (i.e. the DNS01 TXT record has been presented, or the HTTP01 configuration has been configured).
+                  type: boolean
+                processing:
+                  description: Used to denote whether this challenge should be processed or not. This field will only be set to true by the 'scheduling' component. It will only be set to false by the 'challenges' controller, after the challenge has reached a final state or timed out. If this field is set to false, the challenge controller will not take any more action.
+                  type: boolean
+                reason:
+                  description: Contains human readable information on why the Challenge is in the current state.
+                  type: string
+                state:
+                  description: Contains the current 'state' of the challenge. If not set, the state of the challenge is unknown.
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.dnsName
+          name: Domain
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Challenge is a type to represent a Challenge request with an ACME server
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - authorizationURL
+                - dnsName
+                - issuerRef
+                - key
+                - solver
+                - token
+                - type
+                - url
+              properties:
+                authorizationURL:
+                  description: The URL to the ACME Authorization resource that this challenge is a part of.
+                  type: string
+                dnsName:
+                  description: dnsName is the identifier that this challenge is for, e.g. example.com. If the requested DNSName is a 'wildcard', this field MUST be set to the non-wildcard domain, e.g. for `*.example.com`, it must be `example.com`.
+                  type: string
+                issuerRef:
+                  description: References a properly configured ACME-type Issuer which should be used to create this Challenge. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Challenge will be marked as failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                key:
+                  description: 'The ACME challenge key for this challenge For HTTP01 challenges, this is the value that must be responded with to complete the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key from acme server for challenge>`. For DNS01 challenges, this is the base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key from acme server for challenge>` text that must be set as the TXT record content.'
+                  type: string
+                solver:
+                  description: Contains the domain solving configuration that should be used to solve this challenge resource.
+                  type: object
+                  properties:
+                    dns01:
+                      description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                      type: object
+                      properties:
+                        acmeDNS:
+                          description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - accountSecretRef
+                            - host
+                          properties:
+                            accountSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            host:
+                              type: string
+                        akamai:
+                          description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                          properties:
+                            accessTokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            clientSecretSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            clientTokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceConsumerDomain:
+                              type: string
+                        azureDNS:
+                          description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - resourceGroupName
+                            - subscriptionID
+                          properties:
+                            clientID:
+                              description: if both this and ClientSecret are left unset MSI will be used
+                              type: string
+                            clientSecretSecretRef:
+                              description: if both this and ClientID are left unset MSI will be used
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            environment:
+                              type: string
+                              enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                            hostedZoneName:
+                              type: string
+                            resourceGroupName:
+                              type: string
+                            subscriptionID:
+                              type: string
+                            tenantID:
+                              description: when specifying ClientID and ClientSecret then this field is also needed
+                              type: string
+                        cloudDNS:
+                          description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - project
+                          properties:
+                            hostedZoneName:
+                              description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                              type: string
+                            project:
+                              type: string
+                            serviceAccountSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        cloudflare:
+                          description: Use the Cloudflare API to manage DNS01 challenge records.
+                          type: object
+                          properties:
+                            apiKeySecretRef:
+                              description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            apiTokenSecretRef:
+                              description: API token used to authenticate with Cloudflare.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            email:
+                              description: Email of the account, only required when using API key based authentication.
+                              type: string
+                        cnameStrategy:
+                          description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                          type: string
+                          enum:
+                            - None
+                            - Follow
+                        digitalocean:
+                          description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - tokenSecretRef
+                          properties:
+                            tokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        rfc2136:
+                          description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - nameserver
+                          properties:
+                            nameserver:
+                              description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                              type: string
+                            tsigAlgorithm:
+                              description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                              type: string
+                            tsigKeyName:
+                              description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                              type: string
+                            tsigSecretSecretRef:
+                              description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        route53:
+                          description: Use the AWS Route53 API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - region
+                          properties:
+                            accessKeyID:
+                              description: 'The AccessKeyID is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                              type: string
+                            hostedZoneID:
+                              description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                              type: string
+                            region:
+                              description: Always set the region when using AccessKeyID and SecretAccessKey
+                              type: string
+                            role:
+                              description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                              type: string
+                            secretAccessKeySecretRef:
+                              description: The SecretAccessKey is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        webhook:
+                          description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - groupName
+                            - solverName
+                          properties:
+                            config:
+                              description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                              x-kubernetes-preserve-unknown-fields: true
+                            groupName:
+                              description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                              type: string
+                            solverName:
+                              description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                              type: string
+                    http01:
+                      description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                      type: object
+                      properties:
+                        gatewayHTTPRoute:
+                          description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                          type: object
+                          properties:
+                            labels:
+                              description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                              type: object
+                              additionalProperties:
+                                type: string
+                            serviceType:
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                              type: string
+                        ingress:
+                          description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                          type: object
+                          properties:
+                            class:
+                              description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                              type: string
+                            ingressTemplate:
+                              description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.
+                              type: object
+                              properties:
+                                metadata:
+                                  description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                            name:
+                              description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                              type: string
+                            podTemplate:
+                              description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
+                              type: object
+                              properties:
+                                metadata:
+                                  description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                spec:
+                                  description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                  type: object
+                                  properties:
+                                    affinity:
+                                      description: If specified, the pod's scheduling constraints
+                                      type: object
+                                      properties:
+                                        nodeAffinity:
+                                          description: Describes node affinity scheduling rules for the pod.
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                type: object
+                                                required:
+                                                  - preference
+                                                  - weight
+                                                properties:
+                                                  preference:
+                                                    description: A node selector term, associated with the corresponding weight.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                  weight:
+                                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                              type: object
+                                              required:
+                                                - nodeSelectorTerms
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  description: Required. A list of node selector terms. The terms are ORed.
+                                                  type: array
+                                                  items:
+                                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                        podAffinity:
+                                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query over a set of resources, in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaceSelector:
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              type: array
+                                              items:
+                                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over a set of resources, in this case pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaceSelector:
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaces:
+                                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                    type: string
+                                        podAntiAffinity:
+                                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query over a set of resources, in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaceSelector:
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              type: array
+                                              items:
+                                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over a set of resources, in this case pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaceSelector:
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaces:
+                                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                    type: string
+                                    nodeSelector:
+                                      description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    priorityClassName:
+                                      description: If specified, the pod's priorityClassName.
+                                      type: string
+                                    serviceAccountName:
+                                      description: If specified, the pod's service account
+                                      type: string
+                                    tolerations:
+                                      description: If specified, the pod's tolerations.
+                                      type: array
+                                      items:
+                                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                        type: object
+                                        properties:
+                                          effect:
+                                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                            type: integer
+                                            format: int64
+                                          value:
+                                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                            type: string
+                            serviceType:
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                              type: string
+                    selector:
+                      description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                      type: object
+                      properties:
+                        dnsNames:
+                          description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                          type: array
+                          items:
+                            type: string
+                        dnsZones:
+                          description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                          type: array
+                          items:
+                            type: string
+                        matchLabels:
+                          description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                          type: object
+                          additionalProperties:
+                            type: string
+                token:
+                  description: The ACME challenge token for this challenge. This is the raw value returned from the ACME server.
+                  type: string
+                type:
+                  description: The type of ACME challenge this resource represents. One of "HTTP-01" or "DNS-01".
+                  type: string
+                  enum:
+                    - HTTP-01
+                    - DNS-01
+                url:
+                  description: The URL of the ACME Challenge resource for this challenge. This can be used to lookup details about the status of this challenge.
+                  type: string
+                wildcard:
+                  description: wildcard will be true if this challenge is for a wildcard identifier, for example '*.example.com'.
+                  type: boolean
+            status:
+              type: object
+              properties:
+                presented:
+                  description: presented will be set to true if the challenge values for this challenge are currently 'presented'. This *does not* imply the self check is passing. Only that the values have been 'submitted' for the appropriate challenge mechanism (i.e. the DNS01 TXT record has been presented, or the HTTP01 configuration has been configured).
+                  type: boolean
+                processing:
+                  description: Used to denote whether this challenge should be processed or not. This field will only be set to true by the 'scheduling' component. It will only be set to false by the 'challenges' controller, after the challenge has reached a final state or timed out. If this field is set to false, the challenge controller will not take any more action.
+                  type: boolean
+                reason:
+                  description: Contains human readable information on why the Challenge is in the current state.
+                  type: string
+                state:
+                  description: Contains the current 'state' of the challenge. If not set, the state of the challenge is unknown.
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/acme.cert-manager.io_orders_crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/acme.cert-manager.io_orders_crd.yaml
@@ -1,0 +1,680 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: orders.acme.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    # Generated labels
+    app.kubernetes.io/version: "v1.5.1"
+spec:
+  group: acme.cert-manager.io
+  names:
+    kind: Order
+    listKind: OrderList
+    plural: orders
+    singular: order
+    categories:
+      - cert-manager
+      - cert-manager-acme
+  scope: Namespaced
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhook:
+      # We don't actually support `v1beta1` but is listed here as it is a
+      # required value for [Kubernetes v1.16](kubernetes/kubernetes#82023). The
+      # API server reads the supported versions in order, so _should always_
+      # attempt a `v1` request which is understood by the cert-manager webhook.
+      # Any `v1beta1` request will return an error and fail closed for that
+      # resource (the whole object request is rejected).
+      # When we no longer support v1.16 we can remove `v1beta1` from this list.
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        #
+        service:
+          name: 'cert-manager-webhook'
+          namespace: "cert-manager"
+          path: /convert
+          #
+  versions:
+    - name: v1alpha2
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: Order is a type to represent an Order with an ACME server
+          type: object
+          required:
+            - metadata
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - csr
+                - issuerRef
+              properties:
+                commonName:
+                  description: CommonName is the common name as specified on the DER encoded CSR. If specified, this value must also be present in `dnsNames` or `ipAddresses`. This field must match the corresponding field on the DER encoded CSR.
+                  type: string
+                csr:
+                  description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
+                  type: string
+                  format: byte
+                dnsNames:
+                  description: DNSNames is a list of DNS names that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
+                  type: array
+                  items:
+                    type: string
+                duration:
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
+                  type: string
+                ipAddresses:
+                  description: IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
+                  type: array
+                  items:
+                    type: string
+                issuerRef:
+                  description: IssuerRef references a properly configured ACME-type Issuer which should be used to create this Order. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Order will be marked as failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+            status:
+              type: object
+              properties:
+                authorizations:
+                  description: Authorizations contains data returned from the ACME server on what authorizations must be completed in order to validate the DNS names specified on the Order.
+                  type: array
+                  items:
+                    description: ACMEAuthorization contains data returned from the ACME server on an authorization that must be completed in order validate a DNS name on an ACME Order resource.
+                    type: object
+                    required:
+                      - url
+                    properties:
+                      challenges:
+                        description: Challenges specifies the challenge types offered by the ACME server. One of these challenge types will be selected when validating the DNS name and an appropriate Challenge resource will be created to perform the ACME challenge process.
+                        type: array
+                        items:
+                          description: Challenge specifies a challenge offered by the ACME server for an Order. An appropriate Challenge resource can be created to perform the ACME challenge process.
+                          type: object
+                          required:
+                            - token
+                            - type
+                            - url
+                          properties:
+                            token:
+                              description: Token is the token that must be presented for this challenge. This is used to compute the 'key' that must also be presented.
+                              type: string
+                            type:
+                              description: Type is the type of challenge being offered, e.g. 'http-01', 'dns-01', 'tls-sni-01', etc. This is the raw value retrieved from the ACME server. Only 'http-01' and 'dns-01' are supported by cert-manager, other values will be ignored.
+                              type: string
+                            url:
+                              description: URL is the URL of this challenge. It can be used to retrieve additional metadata about the Challenge from the ACME server.
+                              type: string
+                      identifier:
+                        description: Identifier is the DNS name to be validated as part of this authorization
+                        type: string
+                      initialState:
+                        description: InitialState is the initial state of the ACME authorization when first fetched from the ACME server. If an Authorization is already 'valid', the Order controller will not create a Challenge resource for the authorization. This will occur when working with an ACME server that enables 'authz reuse' (such as Let's Encrypt's production endpoint). If not set and 'identifier' is set, the state is assumed to be pending and a Challenge will be created.
+                        type: string
+                        enum:
+                          - valid
+                          - ready
+                          - pending
+                          - processing
+                          - invalid
+                          - expired
+                          - errored
+                      url:
+                        description: URL is the URL of the Authorization that must be completed
+                        type: string
+                      wildcard:
+                        description: Wildcard will be true if this authorization is for a wildcard DNS name. If this is true, the identifier will be the *non-wildcard* version of the DNS name. For example, if '*.example.com' is the DNS name being validated, this field will be 'true' and the 'identifier' field will be 'example.com'.
+                        type: boolean
+                certificate:
+                  description: Certificate is a copy of the PEM encoded certificate for this Order. This field will be populated after the order has been successfully finalized with the ACME server, and the order has transitioned to the 'valid' state.
+                  type: string
+                  format: byte
+                failureTime:
+                  description: FailureTime stores the time that this order failed. This is used to influence garbage collection and back-off.
+                  type: string
+                  format: date-time
+                finalizeURL:
+                  description: FinalizeURL of the Order. This is used to obtain certificates for this order once it has been completed.
+                  type: string
+                reason:
+                  description: Reason optionally provides more information about a why the order is in the current state.
+                  type: string
+                state:
+                  description: State contains the current state of this Order resource. States 'success' and 'expired' are 'final'
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+                url:
+                  description: URL of the Order. This will initially be empty when the resource is first created. The Order controller will populate this field when the Order is first processed. This field will be immutable after it is initially set.
+                  type: string
+      served: true
+      storage: false
+    - name: v1alpha3
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: Order is a type to represent an Order with an ACME server
+          type: object
+          required:
+            - metadata
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - csr
+                - issuerRef
+              properties:
+                commonName:
+                  description: CommonName is the common name as specified on the DER encoded CSR. If specified, this value must also be present in `dnsNames` or `ipAddresses`. This field must match the corresponding field on the DER encoded CSR.
+                  type: string
+                csr:
+                  description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
+                  type: string
+                  format: byte
+                dnsNames:
+                  description: DNSNames is a list of DNS names that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
+                  type: array
+                  items:
+                    type: string
+                duration:
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
+                  type: string
+                ipAddresses:
+                  description: IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
+                  type: array
+                  items:
+                    type: string
+                issuerRef:
+                  description: IssuerRef references a properly configured ACME-type Issuer which should be used to create this Order. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Order will be marked as failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+            status:
+              type: object
+              properties:
+                authorizations:
+                  description: Authorizations contains data returned from the ACME server on what authorizations must be completed in order to validate the DNS names specified on the Order.
+                  type: array
+                  items:
+                    description: ACMEAuthorization contains data returned from the ACME server on an authorization that must be completed in order validate a DNS name on an ACME Order resource.
+                    type: object
+                    required:
+                      - url
+                    properties:
+                      challenges:
+                        description: Challenges specifies the challenge types offered by the ACME server. One of these challenge types will be selected when validating the DNS name and an appropriate Challenge resource will be created to perform the ACME challenge process.
+                        type: array
+                        items:
+                          description: Challenge specifies a challenge offered by the ACME server for an Order. An appropriate Challenge resource can be created to perform the ACME challenge process.
+                          type: object
+                          required:
+                            - token
+                            - type
+                            - url
+                          properties:
+                            token:
+                              description: Token is the token that must be presented for this challenge. This is used to compute the 'key' that must also be presented.
+                              type: string
+                            type:
+                              description: Type is the type of challenge being offered, e.g. 'http-01', 'dns-01', 'tls-sni-01', etc. This is the raw value retrieved from the ACME server. Only 'http-01' and 'dns-01' are supported by cert-manager, other values will be ignored.
+                              type: string
+                            url:
+                              description: URL is the URL of this challenge. It can be used to retrieve additional metadata about the Challenge from the ACME server.
+                              type: string
+                      identifier:
+                        description: Identifier is the DNS name to be validated as part of this authorization
+                        type: string
+                      initialState:
+                        description: InitialState is the initial state of the ACME authorization when first fetched from the ACME server. If an Authorization is already 'valid', the Order controller will not create a Challenge resource for the authorization. This will occur when working with an ACME server that enables 'authz reuse' (such as Let's Encrypt's production endpoint). If not set and 'identifier' is set, the state is assumed to be pending and a Challenge will be created.
+                        type: string
+                        enum:
+                          - valid
+                          - ready
+                          - pending
+                          - processing
+                          - invalid
+                          - expired
+                          - errored
+                      url:
+                        description: URL is the URL of the Authorization that must be completed
+                        type: string
+                      wildcard:
+                        description: Wildcard will be true if this authorization is for a wildcard DNS name. If this is true, the identifier will be the *non-wildcard* version of the DNS name. For example, if '*.example.com' is the DNS name being validated, this field will be 'true' and the 'identifier' field will be 'example.com'.
+                        type: boolean
+                certificate:
+                  description: Certificate is a copy of the PEM encoded certificate for this Order. This field will be populated after the order has been successfully finalized with the ACME server, and the order has transitioned to the 'valid' state.
+                  type: string
+                  format: byte
+                failureTime:
+                  description: FailureTime stores the time that this order failed. This is used to influence garbage collection and back-off.
+                  type: string
+                  format: date-time
+                finalizeURL:
+                  description: FinalizeURL of the Order. This is used to obtain certificates for this order once it has been completed.
+                  type: string
+                reason:
+                  description: Reason optionally provides more information about a why the order is in the current state.
+                  type: string
+                state:
+                  description: State contains the current state of this Order resource. States 'success' and 'expired' are 'final'
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+                url:
+                  description: URL of the Order. This will initially be empty when the resource is first created. The Order controller will populate this field when the Order is first processed. This field will be immutable after it is initially set.
+                  type: string
+      served: true
+      storage: false
+    - name: v1beta1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: Order is a type to represent an Order with an ACME server
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - issuerRef
+                - request
+              properties:
+                commonName:
+                  description: CommonName is the common name as specified on the DER encoded CSR. If specified, this value must also be present in `dnsNames` or `ipAddresses`. This field must match the corresponding field on the DER encoded CSR.
+                  type: string
+                dnsNames:
+                  description: DNSNames is a list of DNS names that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
+                  type: array
+                  items:
+                    type: string
+                duration:
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
+                  type: string
+                ipAddresses:
+                  description: IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
+                  type: array
+                  items:
+                    type: string
+                issuerRef:
+                  description: IssuerRef references a properly configured ACME-type Issuer which should be used to create this Order. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Order will be marked as failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                request:
+                  description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
+                  type: string
+                  format: byte
+            status:
+              type: object
+              properties:
+                authorizations:
+                  description: Authorizations contains data returned from the ACME server on what authorizations must be completed in order to validate the DNS names specified on the Order.
+                  type: array
+                  items:
+                    description: ACMEAuthorization contains data returned from the ACME server on an authorization that must be completed in order validate a DNS name on an ACME Order resource.
+                    type: object
+                    required:
+                      - url
+                    properties:
+                      challenges:
+                        description: Challenges specifies the challenge types offered by the ACME server. One of these challenge types will be selected when validating the DNS name and an appropriate Challenge resource will be created to perform the ACME challenge process.
+                        type: array
+                        items:
+                          description: Challenge specifies a challenge offered by the ACME server for an Order. An appropriate Challenge resource can be created to perform the ACME challenge process.
+                          type: object
+                          required:
+                            - token
+                            - type
+                            - url
+                          properties:
+                            token:
+                              description: Token is the token that must be presented for this challenge. This is used to compute the 'key' that must also be presented.
+                              type: string
+                            type:
+                              description: Type is the type of challenge being offered, e.g. 'http-01', 'dns-01', 'tls-sni-01', etc. This is the raw value retrieved from the ACME server. Only 'http-01' and 'dns-01' are supported by cert-manager, other values will be ignored.
+                              type: string
+                            url:
+                              description: URL is the URL of this challenge. It can be used to retrieve additional metadata about the Challenge from the ACME server.
+                              type: string
+                      identifier:
+                        description: Identifier is the DNS name to be validated as part of this authorization
+                        type: string
+                      initialState:
+                        description: InitialState is the initial state of the ACME authorization when first fetched from the ACME server. If an Authorization is already 'valid', the Order controller will not create a Challenge resource for the authorization. This will occur when working with an ACME server that enables 'authz reuse' (such as Let's Encrypt's production endpoint). If not set and 'identifier' is set, the state is assumed to be pending and a Challenge will be created.
+                        type: string
+                        enum:
+                          - valid
+                          - ready
+                          - pending
+                          - processing
+                          - invalid
+                          - expired
+                          - errored
+                      url:
+                        description: URL is the URL of the Authorization that must be completed
+                        type: string
+                      wildcard:
+                        description: Wildcard will be true if this authorization is for a wildcard DNS name. If this is true, the identifier will be the *non-wildcard* version of the DNS name. For example, if '*.example.com' is the DNS name being validated, this field will be 'true' and the 'identifier' field will be 'example.com'.
+                        type: boolean
+                certificate:
+                  description: Certificate is a copy of the PEM encoded certificate for this Order. This field will be populated after the order has been successfully finalized with the ACME server, and the order has transitioned to the 'valid' state.
+                  type: string
+                  format: byte
+                failureTime:
+                  description: FailureTime stores the time that this order failed. This is used to influence garbage collection and back-off.
+                  type: string
+                  format: date-time
+                finalizeURL:
+                  description: FinalizeURL of the Order. This is used to obtain certificates for this order once it has been completed.
+                  type: string
+                reason:
+                  description: Reason optionally provides more information about a why the order is in the current state.
+                  type: string
+                state:
+                  description: State contains the current state of this Order resource. States 'success' and 'expired' are 'final'
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+                url:
+                  description: URL of the Order. This will initially be empty when the resource is first created. The Order controller will populate this field when the Order is first processed. This field will be immutable after it is initially set.
+                  type: string
+      served: true
+      storage: false
+    - name: v1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: Order is a type to represent an Order with an ACME server
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - issuerRef
+                - request
+              properties:
+                commonName:
+                  description: CommonName is the common name as specified on the DER encoded CSR. If specified, this value must also be present in `dnsNames` or `ipAddresses`. This field must match the corresponding field on the DER encoded CSR.
+                  type: string
+                dnsNames:
+                  description: DNSNames is a list of DNS names that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
+                  type: array
+                  items:
+                    type: string
+                duration:
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
+                  type: string
+                ipAddresses:
+                  description: IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
+                  type: array
+                  items:
+                    type: string
+                issuerRef:
+                  description: IssuerRef references a properly configured ACME-type Issuer which should be used to create this Order. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Order will be marked as failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                request:
+                  description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
+                  type: string
+                  format: byte
+            status:
+              type: object
+              properties:
+                authorizations:
+                  description: Authorizations contains data returned from the ACME server on what authorizations must be completed in order to validate the DNS names specified on the Order.
+                  type: array
+                  items:
+                    description: ACMEAuthorization contains data returned from the ACME server on an authorization that must be completed in order validate a DNS name on an ACME Order resource.
+                    type: object
+                    required:
+                      - url
+                    properties:
+                      challenges:
+                        description: Challenges specifies the challenge types offered by the ACME server. One of these challenge types will be selected when validating the DNS name and an appropriate Challenge resource will be created to perform the ACME challenge process.
+                        type: array
+                        items:
+                          description: Challenge specifies a challenge offered by the ACME server for an Order. An appropriate Challenge resource can be created to perform the ACME challenge process.
+                          type: object
+                          required:
+                            - token
+                            - type
+                            - url
+                          properties:
+                            token:
+                              description: Token is the token that must be presented for this challenge. This is used to compute the 'key' that must also be presented.
+                              type: string
+                            type:
+                              description: Type is the type of challenge being offered, e.g. 'http-01', 'dns-01', 'tls-sni-01', etc. This is the raw value retrieved from the ACME server. Only 'http-01' and 'dns-01' are supported by cert-manager, other values will be ignored.
+                              type: string
+                            url:
+                              description: URL is the URL of this challenge. It can be used to retrieve additional metadata about the Challenge from the ACME server.
+                              type: string
+                      identifier:
+                        description: Identifier is the DNS name to be validated as part of this authorization
+                        type: string
+                      initialState:
+                        description: InitialState is the initial state of the ACME authorization when first fetched from the ACME server. If an Authorization is already 'valid', the Order controller will not create a Challenge resource for the authorization. This will occur when working with an ACME server that enables 'authz reuse' (such as Let's Encrypt's production endpoint). If not set and 'identifier' is set, the state is assumed to be pending and a Challenge will be created.
+                        type: string
+                        enum:
+                          - valid
+                          - ready
+                          - pending
+                          - processing
+                          - invalid
+                          - expired
+                          - errored
+                      url:
+                        description: URL is the URL of the Authorization that must be completed
+                        type: string
+                      wildcard:
+                        description: Wildcard will be true if this authorization is for a wildcard DNS name. If this is true, the identifier will be the *non-wildcard* version of the DNS name. For example, if '*.example.com' is the DNS name being validated, this field will be 'true' and the 'identifier' field will be 'example.com'.
+                        type: boolean
+                certificate:
+                  description: Certificate is a copy of the PEM encoded certificate for this Order. This field will be populated after the order has been successfully finalized with the ACME server, and the order has transitioned to the 'valid' state.
+                  type: string
+                  format: byte
+                failureTime:
+                  description: FailureTime stores the time that this order failed. This is used to influence garbage collection and back-off.
+                  type: string
+                  format: date-time
+                finalizeURL:
+                  description: FinalizeURL of the Order. This is used to obtain certificates for this order once it has been completed.
+                  type: string
+                reason:
+                  description: Reason optionally provides more information about a why the order is in the current state.
+                  type: string
+                state:
+                  description: State contains the current state of this Order resource. States 'success' and 'expired' are 'final'
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+                url:
+                  description: URL of the Order. This will initially be empty when the resource is first created. The Order controller will populate this field when the Order is first processed. This field will be immutable after it is initially set.
+                  type: string
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/cert-manager.io_certificaterequests_crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/cert-manager.io_certificaterequests_crd.yaml
@@ -1,0 +1,4729 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterissuers.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    # Generated labels
+    app.kubernetes.io/version: "v1.5.1"
+spec:
+  group: cert-manager.io
+  names:
+    kind: ClusterIssuer
+    listKind: ClusterIssuerList
+    plural: clusterissuers
+    singular: clusterissuer
+    categories:
+      - cert-manager
+  scope: Cluster
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhook:
+      # We don't actually support `v1beta1` but is listed here as it is a
+      # required value for [Kubernetes v1.16](kubernetes/kubernetes#82023). The
+      # API server reads the supported versions in order, so _should always_
+      # attempt a `v1` request which is understood by the cert-manager webhook.
+      # Any `v1beta1` request will return an error and fail closed for that
+      # resource (the whole object request is rejected).
+      # When we no longer support v1.16 we can remove `v1beta1` from this list.
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        #
+        service:
+          name: 'cert-manager-webhook'
+          namespace: "cert-manager"
+          path: /convert
+          #
+  versions:
+    - name: v1alpha2
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: A ClusterIssuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is similar to an Issuer, however it is cluster-scoped and therefore can be referenced by resources that exist in *any* namespace, not just the same namespace as the referent.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the ClusterIssuer resource.
+              type: object
+              properties:
+                acme:
+                  description: ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.
+                  type: object
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
+                    email:
+                      description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
+                      type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
+                      type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: 'Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.'
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
+                      type: string
+                      maxLength: 64
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    server:
+                      description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
+                      type: string
+                    skipTLSVerify:
+                      description: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.
+                      type: boolean
+                    solvers:
+                      description: 'Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                      type: array
+                      items:
+                        description: Configures an issuer to solve challenges using the specified options. Only one of HTTP01 or DNS01 may be provided.
+                        type: object
+                        properties:
+                          dns01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                            type: object
+                            properties:
+                              acmedns:
+                                description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                properties:
+                                  accountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azuredns:
+                                description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: if both this and ClientSecret are left unset MSI will be used
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset MSI will be used
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  environment:
+                                    type: string
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    type: string
+                                  resourceGroupName:
+                                    type: string
+                                  subscriptionID:
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                              clouddns:
+                                description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - project
+                                properties:
+                                  hostedZoneName:
+                                    description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                                    type: string
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              cloudflare:
+                                description: Use the Cloudflare API to manage DNS01 challenge records.
+                                type: object
+                                properties:
+                                  apiKeySecretRef:
+                                    description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    description: API token used to authenticate with Cloudflare.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  email:
+                                    description: Email of the account, only required when using API key based authentication.
+                                    type: string
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                                type: string
+                                enum:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              rfc2136:
+                                description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - nameserver
+                                properties:
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                    type: string
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              route53:
+                                description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - region
+                                properties:
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: Always set the region when using AccessKeyID and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: The SecretAccessKey is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              webhook:
+                                description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - groupName
+                                  - solverName
+                                properties:
+                                  config:
+                                    description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                            type: object
+                            properties:
+                              gatewayHTTPRoute:
+                                description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                                type: object
+                                properties:
+                                  labels:
+                                    description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    type: string
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  description: CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.
+                      type: array
+                      items:
+                        type: string
+                    ocspServers:
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates issued by this Issuer.
+                      type: string
+                selfSigned:
+                  description: SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  description: Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.
+                  type: object
+                  required:
+                    - auth
+                    - path
+                    - server
+                  properties:
+                    auth:
+                      description: Auth configures how cert-manager authenticates with the Vault server.
+                      type: object
+                      properties:
+                        appRole:
+                          description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                              type: string
+                            roleId:
+                              description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                              type: string
+                            secretRef:
+                              description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        kubernetes:
+                          description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                          type: object
+                          required:
+                            - role
+                            - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    caBundle:
+                      description: PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    namespace:
+                      description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                      type: string
+                    path:
+                      description: 'Path is the mount path of the Vault PKI backend''s `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
+                      type: string
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                venafi:
+                  description: Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud. Defaults to "https://api.venafi.cloud/v1".
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: 'URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.
+                      type: string
+            status:
+              description: Status of the ClusterIssuer. This is set and managed automatically.
+              type: object
+              properties:
+                acme:
+                  description: ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  description: List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details of the last transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: Reason is a brief machine readable explanation for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`).
+                        type: string
+      served: true
+      storage: false
+    - name: v1alpha3
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: A ClusterIssuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is similar to an Issuer, however it is cluster-scoped and therefore can be referenced by resources that exist in *any* namespace, not just the same namespace as the referent.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the ClusterIssuer resource.
+              type: object
+              properties:
+                acme:
+                  description: ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.
+                  type: object
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
+                    email:
+                      description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
+                      type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
+                      type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: 'Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.'
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
+                      type: string
+                      maxLength: 64
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    server:
+                      description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
+                      type: string
+                    skipTLSVerify:
+                      description: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.
+                      type: boolean
+                    solvers:
+                      description: 'Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                      type: array
+                      items:
+                        description: Configures an issuer to solve challenges using the specified options. Only one of HTTP01 or DNS01 may be provided.
+                        type: object
+                        properties:
+                          dns01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                            type: object
+                            properties:
+                              acmedns:
+                                description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                properties:
+                                  accountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azuredns:
+                                description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: if both this and ClientSecret are left unset MSI will be used
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset MSI will be used
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  environment:
+                                    type: string
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    type: string
+                                  resourceGroupName:
+                                    type: string
+                                  subscriptionID:
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                              clouddns:
+                                description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - project
+                                properties:
+                                  hostedZoneName:
+                                    description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                                    type: string
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              cloudflare:
+                                description: Use the Cloudflare API to manage DNS01 challenge records.
+                                type: object
+                                properties:
+                                  apiKeySecretRef:
+                                    description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    description: API token used to authenticate with Cloudflare.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  email:
+                                    description: Email of the account, only required when using API key based authentication.
+                                    type: string
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                                type: string
+                                enum:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              rfc2136:
+                                description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - nameserver
+                                properties:
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                    type: string
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              route53:
+                                description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - region
+                                properties:
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: Always set the region when using AccessKeyID and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: The SecretAccessKey is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              webhook:
+                                description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - groupName
+                                  - solverName
+                                properties:
+                                  config:
+                                    description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                            type: object
+                            properties:
+                              gatewayHTTPRoute:
+                                description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                                type: object
+                                properties:
+                                  labels:
+                                    description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP.
+                                    type: string
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  description: CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.
+                      type: array
+                      items:
+                        type: string
+                    ocspServers:
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates issued by this Issuer.
+                      type: string
+                selfSigned:
+                  description: SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  description: Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.
+                  type: object
+                  required:
+                    - auth
+                    - path
+                    - server
+                  properties:
+                    auth:
+                      description: Auth configures how cert-manager authenticates with the Vault server.
+                      type: object
+                      properties:
+                        appRole:
+                          description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                              type: string
+                            roleId:
+                              description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                              type: string
+                            secretRef:
+                              description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        kubernetes:
+                          description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                          type: object
+                          required:
+                            - role
+                            - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    caBundle:
+                      description: PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    namespace:
+                      description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                      type: string
+                    path:
+                      description: 'Path is the mount path of the Vault PKI backend''s `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
+                      type: string
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                venafi:
+                  description: Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud. Defaults to "https://api.venafi.cloud/v1".
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: 'URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.
+                      type: string
+            status:
+              description: Status of the ClusterIssuer. This is set and managed automatically.
+              type: object
+              properties:
+                acme:
+                  description: ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  description: List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details of the last transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: Reason is a brief machine readable explanation for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`).
+                        type: string
+      served: true
+      storage: false
+    - name: v1beta1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: A ClusterIssuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is similar to an Issuer, however it is cluster-scoped and therefore can be referenced by resources that exist in *any* namespace, not just the same namespace as the referent.
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the ClusterIssuer resource.
+              type: object
+              properties:
+                acme:
+                  description: ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.
+                  type: object
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
+                    email:
+                      description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
+                      type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
+                      type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: 'Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.'
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
+                      type: string
+                      maxLength: 64
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    server:
+                      description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
+                      type: string
+                    skipTLSVerify:
+                      description: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.
+                      type: boolean
+                    solvers:
+                      description: 'Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                      type: array
+                      items:
+                        description: Configures an issuer to solve challenges using the specified options. Only one of HTTP01 or DNS01 may be provided.
+                        type: object
+                        properties:
+                          dns01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                            type: object
+                            properties:
+                              acmeDNS:
+                                description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                properties:
+                                  accountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azureDNS:
+                                description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: if both this and ClientSecret are left unset MSI will be used
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset MSI will be used
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  environment:
+                                    type: string
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    type: string
+                                  resourceGroupName:
+                                    type: string
+                                  subscriptionID:
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                              cloudDNS:
+                                description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - project
+                                properties:
+                                  hostedZoneName:
+                                    description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                                    type: string
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              cloudflare:
+                                description: Use the Cloudflare API to manage DNS01 challenge records.
+                                type: object
+                                properties:
+                                  apiKeySecretRef:
+                                    description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    description: API token used to authenticate with Cloudflare.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  email:
+                                    description: Email of the account, only required when using API key based authentication.
+                                    type: string
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                                type: string
+                                enum:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              rfc2136:
+                                description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - nameserver
+                                properties:
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                    type: string
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              route53:
+                                description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - region
+                                properties:
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: Always set the region when using AccessKeyID and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: The SecretAccessKey is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              webhook:
+                                description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - groupName
+                                  - solverName
+                                properties:
+                                  config:
+                                    description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                            type: object
+                            properties:
+                              gatewayHTTPRoute:
+                                description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                                type: object
+                                properties:
+                                  labels:
+                                    description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    type: string
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  description: CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.
+                      type: array
+                      items:
+                        type: string
+                    ocspServers:
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates issued by this Issuer.
+                      type: string
+                selfSigned:
+                  description: SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  description: Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.
+                  type: object
+                  required:
+                    - auth
+                    - path
+                    - server
+                  properties:
+                    auth:
+                      description: Auth configures how cert-manager authenticates with the Vault server.
+                      type: object
+                      properties:
+                        appRole:
+                          description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                              type: string
+                            roleId:
+                              description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                              type: string
+                            secretRef:
+                              description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        kubernetes:
+                          description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                          type: object
+                          required:
+                            - role
+                            - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    caBundle:
+                      description: PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    namespace:
+                      description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                      type: string
+                    path:
+                      description: 'Path is the mount path of the Vault PKI backend''s `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
+                      type: string
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                venafi:
+                  description: Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud. Defaults to "https://api.venafi.cloud/v1".
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: 'URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.
+                      type: string
+            status:
+              description: Status of the ClusterIssuer. This is set and managed automatically.
+              type: object
+              properties:
+                acme:
+                  description: ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  description: List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details of the last transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: Reason is a brief machine readable explanation for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`).
+                        type: string
+      served: true
+      storage: false
+    - name: v1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: A ClusterIssuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is similar to an Issuer, however it is cluster-scoped and therefore can be referenced by resources that exist in *any* namespace, not just the same namespace as the referent.
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the ClusterIssuer resource.
+              type: object
+              properties:
+                acme:
+                  description: ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.
+                  type: object
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
+                    email:
+                      description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
+                      type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
+                      type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: 'Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.'
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
+                      type: string
+                      maxLength: 64
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    server:
+                      description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
+                      type: string
+                    skipTLSVerify:
+                      description: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.
+                      type: boolean
+                    solvers:
+                      description: 'Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                      type: array
+                      items:
+                        description: An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of. A selector may be provided to use different solving strategies for different DNS names. Only one of HTTP01 or DNS01 must be provided.
+                        type: object
+                        properties:
+                          dns01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                            type: object
+                            properties:
+                              acmeDNS:
+                                description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                properties:
+                                  accountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azureDNS:
+                                description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: if both this and ClientSecret are left unset MSI will be used
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset MSI will be used
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  environment:
+                                    type: string
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    type: string
+                                  resourceGroupName:
+                                    type: string
+                                  subscriptionID:
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                              cloudDNS:
+                                description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - project
+                                properties:
+                                  hostedZoneName:
+                                    description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                                    type: string
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              cloudflare:
+                                description: Use the Cloudflare API to manage DNS01 challenge records.
+                                type: object
+                                properties:
+                                  apiKeySecretRef:
+                                    description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    description: API token used to authenticate with Cloudflare.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  email:
+                                    description: Email of the account, only required when using API key based authentication.
+                                    type: string
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                                type: string
+                                enum:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              rfc2136:
+                                description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - nameserver
+                                properties:
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                    type: string
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              route53:
+                                description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - region
+                                properties:
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: Always set the region when using AccessKeyID and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: The SecretAccessKey is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              webhook:
+                                description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - groupName
+                                  - solverName
+                                properties:
+                                  config:
+                                    description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                            type: object
+                            properties:
+                              gatewayHTTPRoute:
+                                description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                                type: object
+                                properties:
+                                  labels:
+                                    description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    type: string
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  description: CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.
+                      type: array
+                      items:
+                        type: string
+                    ocspServers:
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates issued by this Issuer.
+                      type: string
+                selfSigned:
+                  description: SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  description: Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.
+                  type: object
+                  required:
+                    - auth
+                    - path
+                    - server
+                  properties:
+                    auth:
+                      description: Auth configures how cert-manager authenticates with the Vault server.
+                      type: object
+                      properties:
+                        appRole:
+                          description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                              type: string
+                            roleId:
+                              description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                              type: string
+                            secretRef:
+                              description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        kubernetes:
+                          description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                          type: object
+                          required:
+                            - role
+                            - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    caBundle:
+                      description: PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    namespace:
+                      description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                      type: string
+                    path:
+                      description: 'Path is the mount path of the Vault PKI backend''s `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
+                      type: string
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                venafi:
+                  description: Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud. Defaults to "https://api.venafi.cloud/v1".
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: 'URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.
+                      type: string
+            status:
+              description: Status of the ClusterIssuer. This is set and managed automatically.
+              type: object
+              properties:
+                acme:
+                  description: ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  description: List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details of the last transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: Reason is a brief machine readable explanation for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`).
+                        type: string
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/cert-manager.io_clusterissuers_crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/cert-manager.io_clusterissuers_crd.yaml
@@ -1,0 +1,4729 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterissuers.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    # Generated labels
+    app.kubernetes.io/version: "v1.5.1"
+spec:
+  group: cert-manager.io
+  names:
+    kind: ClusterIssuer
+    listKind: ClusterIssuerList
+    plural: clusterissuers
+    singular: clusterissuer
+    categories:
+      - cert-manager
+  scope: Cluster
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhook:
+      # We don't actually support `v1beta1` but is listed here as it is a
+      # required value for [Kubernetes v1.16](kubernetes/kubernetes#82023). The
+      # API server reads the supported versions in order, so _should always_
+      # attempt a `v1` request which is understood by the cert-manager webhook.
+      # Any `v1beta1` request will return an error and fail closed for that
+      # resource (the whole object request is rejected).
+      # When we no longer support v1.16 we can remove `v1beta1` from this list.
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        #
+        service:
+          name: 'cert-manager-webhook'
+          namespace: "cert-manager"
+          path: /convert
+          #
+  versions:
+    - name: v1alpha2
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: A ClusterIssuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is similar to an Issuer, however it is cluster-scoped and therefore can be referenced by resources that exist in *any* namespace, not just the same namespace as the referent.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the ClusterIssuer resource.
+              type: object
+              properties:
+                acme:
+                  description: ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.
+                  type: object
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
+                    email:
+                      description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
+                      type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
+                      type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: 'Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.'
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
+                      type: string
+                      maxLength: 64
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    server:
+                      description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
+                      type: string
+                    skipTLSVerify:
+                      description: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.
+                      type: boolean
+                    solvers:
+                      description: 'Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                      type: array
+                      items:
+                        description: Configures an issuer to solve challenges using the specified options. Only one of HTTP01 or DNS01 may be provided.
+                        type: object
+                        properties:
+                          dns01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                            type: object
+                            properties:
+                              acmedns:
+                                description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                properties:
+                                  accountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azuredns:
+                                description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: if both this and ClientSecret are left unset MSI will be used
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset MSI will be used
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  environment:
+                                    type: string
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    type: string
+                                  resourceGroupName:
+                                    type: string
+                                  subscriptionID:
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                              clouddns:
+                                description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - project
+                                properties:
+                                  hostedZoneName:
+                                    description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                                    type: string
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              cloudflare:
+                                description: Use the Cloudflare API to manage DNS01 challenge records.
+                                type: object
+                                properties:
+                                  apiKeySecretRef:
+                                    description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    description: API token used to authenticate with Cloudflare.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  email:
+                                    description: Email of the account, only required when using API key based authentication.
+                                    type: string
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                                type: string
+                                enum:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              rfc2136:
+                                description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - nameserver
+                                properties:
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                    type: string
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              route53:
+                                description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - region
+                                properties:
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: Always set the region when using AccessKeyID and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: The SecretAccessKey is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              webhook:
+                                description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - groupName
+                                  - solverName
+                                properties:
+                                  config:
+                                    description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                            type: object
+                            properties:
+                              gatewayHTTPRoute:
+                                description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                                type: object
+                                properties:
+                                  labels:
+                                    description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    type: string
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  description: CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.
+                      type: array
+                      items:
+                        type: string
+                    ocspServers:
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates issued by this Issuer.
+                      type: string
+                selfSigned:
+                  description: SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  description: Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.
+                  type: object
+                  required:
+                    - auth
+                    - path
+                    - server
+                  properties:
+                    auth:
+                      description: Auth configures how cert-manager authenticates with the Vault server.
+                      type: object
+                      properties:
+                        appRole:
+                          description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                              type: string
+                            roleId:
+                              description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                              type: string
+                            secretRef:
+                              description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        kubernetes:
+                          description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                          type: object
+                          required:
+                            - role
+                            - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    caBundle:
+                      description: PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    namespace:
+                      description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                      type: string
+                    path:
+                      description: 'Path is the mount path of the Vault PKI backend''s `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
+                      type: string
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                venafi:
+                  description: Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud. Defaults to "https://api.venafi.cloud/v1".
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: 'URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.
+                      type: string
+            status:
+              description: Status of the ClusterIssuer. This is set and managed automatically.
+              type: object
+              properties:
+                acme:
+                  description: ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  description: List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details of the last transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: Reason is a brief machine readable explanation for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`).
+                        type: string
+      served: true
+      storage: false
+    - name: v1alpha3
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: A ClusterIssuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is similar to an Issuer, however it is cluster-scoped and therefore can be referenced by resources that exist in *any* namespace, not just the same namespace as the referent.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the ClusterIssuer resource.
+              type: object
+              properties:
+                acme:
+                  description: ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.
+                  type: object
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
+                    email:
+                      description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
+                      type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
+                      type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: 'Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.'
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
+                      type: string
+                      maxLength: 64
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    server:
+                      description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
+                      type: string
+                    skipTLSVerify:
+                      description: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.
+                      type: boolean
+                    solvers:
+                      description: 'Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                      type: array
+                      items:
+                        description: Configures an issuer to solve challenges using the specified options. Only one of HTTP01 or DNS01 may be provided.
+                        type: object
+                        properties:
+                          dns01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                            type: object
+                            properties:
+                              acmedns:
+                                description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                properties:
+                                  accountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azuredns:
+                                description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: if both this and ClientSecret are left unset MSI will be used
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset MSI will be used
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  environment:
+                                    type: string
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    type: string
+                                  resourceGroupName:
+                                    type: string
+                                  subscriptionID:
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                              clouddns:
+                                description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - project
+                                properties:
+                                  hostedZoneName:
+                                    description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                                    type: string
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              cloudflare:
+                                description: Use the Cloudflare API to manage DNS01 challenge records.
+                                type: object
+                                properties:
+                                  apiKeySecretRef:
+                                    description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    description: API token used to authenticate with Cloudflare.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  email:
+                                    description: Email of the account, only required when using API key based authentication.
+                                    type: string
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                                type: string
+                                enum:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              rfc2136:
+                                description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - nameserver
+                                properties:
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                    type: string
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              route53:
+                                description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - region
+                                properties:
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: Always set the region when using AccessKeyID and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: The SecretAccessKey is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              webhook:
+                                description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - groupName
+                                  - solverName
+                                properties:
+                                  config:
+                                    description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                            type: object
+                            properties:
+                              gatewayHTTPRoute:
+                                description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                                type: object
+                                properties:
+                                  labels:
+                                    description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP.
+                                    type: string
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  description: CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.
+                      type: array
+                      items:
+                        type: string
+                    ocspServers:
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates issued by this Issuer.
+                      type: string
+                selfSigned:
+                  description: SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  description: Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.
+                  type: object
+                  required:
+                    - auth
+                    - path
+                    - server
+                  properties:
+                    auth:
+                      description: Auth configures how cert-manager authenticates with the Vault server.
+                      type: object
+                      properties:
+                        appRole:
+                          description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                              type: string
+                            roleId:
+                              description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                              type: string
+                            secretRef:
+                              description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        kubernetes:
+                          description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                          type: object
+                          required:
+                            - role
+                            - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    caBundle:
+                      description: PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    namespace:
+                      description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                      type: string
+                    path:
+                      description: 'Path is the mount path of the Vault PKI backend''s `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
+                      type: string
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                venafi:
+                  description: Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud. Defaults to "https://api.venafi.cloud/v1".
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: 'URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.
+                      type: string
+            status:
+              description: Status of the ClusterIssuer. This is set and managed automatically.
+              type: object
+              properties:
+                acme:
+                  description: ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  description: List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details of the last transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: Reason is a brief machine readable explanation for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`).
+                        type: string
+      served: true
+      storage: false
+    - name: v1beta1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: A ClusterIssuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is similar to an Issuer, however it is cluster-scoped and therefore can be referenced by resources that exist in *any* namespace, not just the same namespace as the referent.
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the ClusterIssuer resource.
+              type: object
+              properties:
+                acme:
+                  description: ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.
+                  type: object
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
+                    email:
+                      description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
+                      type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
+                      type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: 'Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.'
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
+                      type: string
+                      maxLength: 64
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    server:
+                      description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
+                      type: string
+                    skipTLSVerify:
+                      description: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.
+                      type: boolean
+                    solvers:
+                      description: 'Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                      type: array
+                      items:
+                        description: Configures an issuer to solve challenges using the specified options. Only one of HTTP01 or DNS01 may be provided.
+                        type: object
+                        properties:
+                          dns01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                            type: object
+                            properties:
+                              acmeDNS:
+                                description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                properties:
+                                  accountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azureDNS:
+                                description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: if both this and ClientSecret are left unset MSI will be used
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset MSI will be used
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  environment:
+                                    type: string
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    type: string
+                                  resourceGroupName:
+                                    type: string
+                                  subscriptionID:
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                              cloudDNS:
+                                description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - project
+                                properties:
+                                  hostedZoneName:
+                                    description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                                    type: string
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              cloudflare:
+                                description: Use the Cloudflare API to manage DNS01 challenge records.
+                                type: object
+                                properties:
+                                  apiKeySecretRef:
+                                    description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    description: API token used to authenticate with Cloudflare.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  email:
+                                    description: Email of the account, only required when using API key based authentication.
+                                    type: string
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                                type: string
+                                enum:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              rfc2136:
+                                description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - nameserver
+                                properties:
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                    type: string
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              route53:
+                                description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - region
+                                properties:
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: Always set the region when using AccessKeyID and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: The SecretAccessKey is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              webhook:
+                                description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - groupName
+                                  - solverName
+                                properties:
+                                  config:
+                                    description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                            type: object
+                            properties:
+                              gatewayHTTPRoute:
+                                description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                                type: object
+                                properties:
+                                  labels:
+                                    description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    type: string
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  description: CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.
+                      type: array
+                      items:
+                        type: string
+                    ocspServers:
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates issued by this Issuer.
+                      type: string
+                selfSigned:
+                  description: SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  description: Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.
+                  type: object
+                  required:
+                    - auth
+                    - path
+                    - server
+                  properties:
+                    auth:
+                      description: Auth configures how cert-manager authenticates with the Vault server.
+                      type: object
+                      properties:
+                        appRole:
+                          description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                              type: string
+                            roleId:
+                              description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                              type: string
+                            secretRef:
+                              description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        kubernetes:
+                          description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                          type: object
+                          required:
+                            - role
+                            - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    caBundle:
+                      description: PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    namespace:
+                      description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                      type: string
+                    path:
+                      description: 'Path is the mount path of the Vault PKI backend''s `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
+                      type: string
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                venafi:
+                  description: Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud. Defaults to "https://api.venafi.cloud/v1".
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: 'URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.
+                      type: string
+            status:
+              description: Status of the ClusterIssuer. This is set and managed automatically.
+              type: object
+              properties:
+                acme:
+                  description: ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  description: List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details of the last transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: Reason is a brief machine readable explanation for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`).
+                        type: string
+      served: true
+      storage: false
+    - name: v1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: A ClusterIssuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is similar to an Issuer, however it is cluster-scoped and therefore can be referenced by resources that exist in *any* namespace, not just the same namespace as the referent.
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the ClusterIssuer resource.
+              type: object
+              properties:
+                acme:
+                  description: ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.
+                  type: object
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
+                    email:
+                      description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
+                      type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
+                      type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: 'Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.'
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
+                      type: string
+                      maxLength: 64
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    server:
+                      description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
+                      type: string
+                    skipTLSVerify:
+                      description: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.
+                      type: boolean
+                    solvers:
+                      description: 'Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                      type: array
+                      items:
+                        description: An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of. A selector may be provided to use different solving strategies for different DNS names. Only one of HTTP01 or DNS01 must be provided.
+                        type: object
+                        properties:
+                          dns01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                            type: object
+                            properties:
+                              acmeDNS:
+                                description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                properties:
+                                  accountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azureDNS:
+                                description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: if both this and ClientSecret are left unset MSI will be used
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset MSI will be used
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  environment:
+                                    type: string
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    type: string
+                                  resourceGroupName:
+                                    type: string
+                                  subscriptionID:
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                              cloudDNS:
+                                description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - project
+                                properties:
+                                  hostedZoneName:
+                                    description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                                    type: string
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              cloudflare:
+                                description: Use the Cloudflare API to manage DNS01 challenge records.
+                                type: object
+                                properties:
+                                  apiKeySecretRef:
+                                    description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    description: API token used to authenticate with Cloudflare.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  email:
+                                    description: Email of the account, only required when using API key based authentication.
+                                    type: string
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                                type: string
+                                enum:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              rfc2136:
+                                description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - nameserver
+                                properties:
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                    type: string
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              route53:
+                                description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - region
+                                properties:
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: Always set the region when using AccessKeyID and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: The SecretAccessKey is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              webhook:
+                                description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - groupName
+                                  - solverName
+                                properties:
+                                  config:
+                                    description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                            type: object
+                            properties:
+                              gatewayHTTPRoute:
+                                description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                                type: object
+                                properties:
+                                  labels:
+                                    description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    type: string
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  description: CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.
+                      type: array
+                      items:
+                        type: string
+                    ocspServers:
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates issued by this Issuer.
+                      type: string
+                selfSigned:
+                  description: SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  description: Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.
+                  type: object
+                  required:
+                    - auth
+                    - path
+                    - server
+                  properties:
+                    auth:
+                      description: Auth configures how cert-manager authenticates with the Vault server.
+                      type: object
+                      properties:
+                        appRole:
+                          description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                              type: string
+                            roleId:
+                              description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                              type: string
+                            secretRef:
+                              description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        kubernetes:
+                          description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                          type: object
+                          required:
+                            - role
+                            - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    caBundle:
+                      description: PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    namespace:
+                      description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                      type: string
+                    path:
+                      description: 'Path is the mount path of the Vault PKI backend''s `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
+                      type: string
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                venafi:
+                  description: Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud. Defaults to "https://api.venafi.cloud/v1".
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: 'URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.
+                      type: string
+            status:
+              description: Status of the ClusterIssuer. This is set and managed automatically.
+              type: object
+              properties:
+                acme:
+                  description: ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  description: List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details of the last transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: Reason is a brief machine readable explanation for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`).
+                        type: string
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/ibm-cert-manager-operator.v3.13.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/ibm-cert-manager-operator.v3.13.0.clusterserviceversion.yaml
@@ -397,6 +397,9 @@ spec:
               - orders/status
               - issuers/status
               - clusterissuers/status
+              - issuers/finalizers
+              - clusterissuers/finalizers
+              - certificaterequests/finalizers
               - certificates/finalizers
               - challenges/finalizers
               - orders/finalizers

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/ibm-cert-manager-operator.v3.13.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/ibm-cert-manager-operator.v3.13.0.clusterserviceversion.yaml
@@ -209,6 +209,34 @@ spec:
           serviceAccountName: ibm-cert-manager-operator
       clusterPermissions:
         - rules:
+            - apiGroups: [""]
+              resources: ["events"]
+              verbs: ["get", "create", "update", "patch"]
+
+            - apiGroups: ["auditregistration.k8s.io"]
+              resources: ["auditsinks"]
+              verbs: ["get", "list", "watch", "update"]
+
+            - apiGroups: ["coordination.k8s.io"]
+              resources: ["leases"]
+              resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"]
+              verbs: ["get", "update", "patch"]
+            - apiGroups: ["coordination.k8s.io"]
+              resources: ["leases"]
+              verbs: ["create"]
+
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - roles
+                - rolebindings
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - delete
+
             - apiGroups:
                 - cert-manager.io
               resources:

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/ibm-cert-manager-operator.v3.13.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/ibm-cert-manager-operator.v3.13.0.clusterserviceversion.yaml
@@ -209,6 +209,369 @@ spec:
           serviceAccountName: ibm-cert-manager-operator
       clusterPermissions:
         - rules:
+            # Can't make the CR namespace-scoped as the operator needs permission to deploy cluster-scoped resources
+            - apiGroups:
+              - operator.ibm.com
+              resources:
+              - certmanagers
+              - certmanagers/status
+              - certmanagers/finalizers
+              verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+            # required by operator to perform operations on CRDs (all the cert-manager operand CRDs)
+            - apiGroups:
+              - apiextensions.k8s.io
+              resources:
+              - customresourcedefinitions
+              verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+            # operator creates clusterrole, clusterrolebinding for the cert-manager operands. 
+            # creates rolebinding as cert-manager-webhook needs to access a configmap in kube-system, so it needs to create a rolebinding in kube-system
+            - apiGroups:
+              - rbac.authorization.k8s.io
+              resources:
+              - clusterroles
+              - clusterrolebindings
+              - rolebindings
+              - roles
+              verbs:
+              - create
+              - get
+              - list
+              - watch
+              - delete
+              - update
+            # operator deploys cert-manager-webhook apiservice
+            - apiGroups:
+              - apiregistration.k8s.io
+              resources:
+              - apiservices
+              verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch 
+            # operator needs to create mutatingwebhookconfigurations, validatingwebhookconfigurations as a part of webhook resources
+            - apiGroups:
+              - admissionregistration.k8s.io
+              resources:
+              - mutatingwebhookconfigurations
+              - validatingwebhookconfigurations
+              verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch 
+            # operator needs cluster-wide access to all the below resources because these are a part of clusterrole for operands
+            # to create a clusterrole with the below permissions, the creator must also have those permissions, in this case, the operator
+
+            # cert-manager service needs to perform all operations on cert-manager resources in any namespace
+            - apiGroups:
+              - cert-manager.io
+              resources:
+              - certificates
+              - certificaterequests
+              - orders
+              - challenges
+              - clusterissuers
+              - issuers
+              verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+              - deletecollection
+            - apiGroups:
+              - cert-manager.io
+              resources:
+              - signers
+              verbs:
+              - approve
+            - apiGroups:
+              - certificates.k8s.io
+              resources:
+              - signers
+              verbs:
+              - sign
+            - apiGroups:
+              - certificates.k8s.io
+              resources:
+              - certificatesigningrequests
+              verbs:
+              - get
+              - list
+              - update
+              - watch
+            - apiGroups:
+              - certificates.k8s.io
+              resources:
+              - certificatesigningrequests/status
+              verbs:
+              - update
+            - apiGroups:
+              - authorization.k8s.io
+              resources:
+              - subjectaccessreviews
+              verbs:
+              - create
+            - apiGroups:
+              - acme.cert-manager.io
+              resources:
+              - orders
+              - challenges
+              verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+              - deletecollection
+            - apiGroups:
+              - certmanager.k8s.io
+              resources:
+              - certificates
+              - certificaterequests
+              - orders
+              - challenges
+              - clusterissuers
+              - issuers
+              verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+            - apiGroups:
+              - cert-manager.io
+              resources:
+              - certificates/status
+              - certificaterequests/status
+              - issuers/status
+              - clusterissuers/status
+              - certificates/finalizers
+              - certificaterequests/finalizers
+              - issuers/finalizers
+              - clusterissuers/finalizers
+              verbs:
+              - update
+            - apiGroups:
+              - acme.cert-manager.io
+              resources:
+              - challenges/status
+              - orders/status
+              - challenges/finalizers
+              - orders/finalizers
+              verbs:
+              - update
+            - apiGroups:
+              - certmanager.k8s.io
+              resources:
+              - certificates/status
+              - certificaterequests/status
+              - challenges/status
+              - orders/status
+              - issuers/status
+              - clusterissuers/status
+              - certificates/finalizers
+              - challenges/finalizers
+              - orders/finalizers
+              verbs:
+              - update
+            # cert-manager service needs permission to perform operations on secrets associated with the certs(eg: perform renewal, etc.)
+            - apiGroups:
+              - ""
+              resources:
+              - secrets
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - delete
+            # cert-manager service needs access to create and patch events for cert-manager resources
+            - apiGroups:
+              - ""
+              resources:
+              - events
+              verbs:
+              - create
+              - patch
+            # only list/watch permission to service-accounts
+            - apiGroups:
+              - ""
+              resources:
+              - serviceaccounts
+              verbs:
+              - list
+              - watch
+            # cert-manager service needs this for HTTP01 rules
+            - apiGroups:
+              - ""
+              resources:
+              - pods
+              - services
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+            - apiGroups:
+              - networking.x-k8s.io
+              resources:
+              - gateways
+              - httproutes
+              - gateways/finalizers
+              - httproutes/finalizers
+              verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+            - apiGroups:
+              - route.openshift.io
+              resources:
+              - routes/custom-host
+              verbs:
+              - create
+
+            # cert-manager service needs this to support inject ca bundle injection in ingresses
+            - apiGroups:
+              - networking.k8s.io
+              resources:
+              - ingresses
+              - ingresses/finalizers
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+              - update
+            # needed by cert-manager service to support pod-refresh after cert renewal feature
+            # also needed by configmap-watcher
+            - apiGroups:
+              - apps
+              resources:
+              - deployments
+              - statefulsets
+              - daemonsets
+              verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+            # need access to configmaps by both cert-manager and configmap-watcher service
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              verbs:
+              - create
+              - delete
+              - get
+              - list
+              - update
+              - watch
+              - patch
+            # needed by cert-manager-webhook for cert-manager resources admission 
+            - apiGroups:
+              - admission.certmanager.k8s.io
+              resources:
+              - certificates
+              - clusterissuers
+              - issuers
+              - certificaterequests
+              verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+            # needed by the operator to enable/disable hostNetwork for cert-manager-webhook
+            - apiGroups:
+              - security.openshift.io
+              resourceNames:
+              - restricted
+              - hostnetwork
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - use
+            # needed by cert-manager-webhook for api server authorization/authentication
+            - apiGroups:
+              - authorization.k8s.io
+              resources:
+              - subjectaccessreviews
+              verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch 
+            # needed by the operator to detect RHACM is installed
+            - apiGroups:
+              - operator.open-cluster-management.io
+              resources:
+              - multiclusterhubs
+              verbs:
+              - get
+              - list
+              - watch
+            # required by the operator to list/watch at cluster level as operator cache needs it due to cluster-scoped operator
+            - apiGroups:
+              - ibmcpcs.ibm.com
+              resources:
+              - secretshares
+              verbs:
+              - list
+              - watch
+            # required by the certificate refresh controller to find certificates based on clusterissuer
+            - apiGroups:
+              - ""
+              resources:
+              - namespaces
+              verbs:
+              - get
+              - list
+              - watch
+
             - apiGroups: [""]
               resources: ["events"]
               verbs: ["get", "create", "update", "patch"]
@@ -219,264 +582,11 @@ spec:
 
             - apiGroups: ["coordination.k8s.io"]
               resources: ["leases"]
-              resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"]
+              resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core", "cert-manager-controller"]
               verbs: ["get", "update", "patch"]
             - apiGroups: ["coordination.k8s.io"]
               resources: ["leases"]
               verbs: ["create"]
-
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - roles
-                - rolebindings
-              verbs:
-                - create
-                - get
-                - list
-                - watch
-                - delete
-
-            - apiGroups:
-                - cert-manager.io
-              resources:
-                - certificates
-                - issuers
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - operator.ibm.com
-              resources:
-                - certmanagers
-                - certmanagers/status
-                - certmanagers/finalizers
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - apiextensions.k8s.io
-              resources:
-                - customresourcedefinitions
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - clusterroles
-                - clusterrolebindings
-                - rolebindings
-              verbs:
-                - create
-                - get
-                - list
-                - watch
-                - delete
-            - apiGroups:
-                - apiregistration.k8s.io
-              resources:
-                - apiservices
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - admissionregistration.k8s.io
-              resources:
-                - mutatingwebhookconfigurations
-                - validatingwebhookconfigurations
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - certmanager.k8s.io
-              resources:
-                - certificates
-                - certificaterequests
-                - orders
-                - challenges
-                - clusterissuers
-                - issuers
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - certmanager.k8s.io
-              resources:
-                - certificates/status
-                - certificaterequests/status
-                - challenges/status
-                - orders/status
-                - issuers/status
-                - clusterissuers/status
-                - certificates/finalizers
-                - challenges/finalizers
-                - ingresses/finalizers
-                - orders/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - ""
-              resources:
-                - secrets
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - update
-                - delete
-            - apiGroups:
-                - ""
-              resources:
-                - events
-              verbs:
-                - create
-                - patch
-            - apiGroups:
-                - ""
-              resources:
-                - serviceaccounts
-              verbs:
-                - list
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - pods
-                - services
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - delete
-            - apiGroups:
-                - extensions
-              resources:
-                - ingresses
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - delete
-                - update
-            - apiGroups:
-                - apps
-              resources:
-                - deployments
-                - statefulsets
-                - daemonsets
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-                - patch
-            - apiGroups:
-                - admission.certmanager.k8s.io
-              resources:
-                - certificates
-                - clusterissuers
-                - issuers
-                - certificaterequests
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - security.openshift.io
-              resourceNames:
-                - restricted
-                - hostnetwork
-              resources:
-                - securitycontextconstraints
-              verbs:
-                - use
-            - apiGroups:
-                - authorization.k8s.io
-              resources:
-                - subjectaccessreviews
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - operator.open-cluster-management.io
-              resources:
-                - multiclusterhubs
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - ibmcpcs.ibm.com
-              resources:
-                - secretshares
-              verbs:
-                - list
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - namespaces
-              verbs:
-                - get
-                - list
-                - watch
           serviceAccountName: ibm-cert-manager-operator
       deployments:
         - name: ibm-cert-manager-operator
@@ -519,13 +629,13 @@ spec:
                       - ibm-cert-manager-operator
                     env:
                       - name: ICP_CERT_MANAGER_CONTROLLER_IMAGE
-                        value: quay.io/opencloudio/icp-cert-manager-controller:1.0.0-jetstack.1.5.1
+                        value: hyc-cloud-private-scratch-docker-local.artifactory.swg-devops.com/ibmcom/icp-cert-manager-controller:dev
                       - name: ICP_CERT_MANAGER_WEBHOOK_IMAGE
-                        value: quay.io/opencloudio/icp-cert-manager-webhook:1.0.0-jetstack.1.5.1
+                        value: hyc-cloud-private-scratch-docker-local.artifactory.swg-devops.com/ibmcom/icp-cert-manager-webhook:dev
                       - name: ICP_CERT_MANAGER_CAINJECTOR_IMAGE
-                        value: quay.io/opencloudio/icp-cert-manager-cainjector:1.0.0-jetstack.1.5.1
+                        value: hyc-cloud-private-scratch-docker-local.artifactory.swg-devops.com/ibmcom/icp-cert-manager-cainjector:dev
                       - name: ICP_CERT_MANAGER_ACMESOLVER_IMAGE
-                        value: quay.io/opencloudio/icp-cert-manager-acmesolver:1.0.0-jetstack.1.5.1
+                        value: hyc-cloud-private-scratch-docker-local.artifactory.swg-devops.com/ibmcom/icp-cert-manager-acmesolver:dev
                       - name: ICP_CONFIGMAP_WATCHER_IMAGE
                         value: quay.io/opencloudio/icp-configmap-watcher:3.8.0
                       - name: WATCH_NAMESPACE
@@ -542,7 +652,7 @@ spec:
                             fieldPath: metadata.namespace
                       - name: OPERATOR_NAME
                         value: ibm-cert-manager-operator
-                    image: quay.io/opencloudio/ibm-cert-manager-operator:latest
+                    image: quay.io/horis233/ibm-certmanager-operator
                     imagePullPolicy: Always
                     name: ibm-cert-manager-operator
                     resources:

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/operator.ibm.com_certmanagers_crd.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/operator.ibm.com_certmanagers_crd.yaml
@@ -15,201 +15,167 @@ spec:
     singular: certmanager
   scope: Cluster
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: CertManager is the Schema for the certmanagers API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: CertManagerSpec defines the desired state of CertManager
-            properties:
-              certManagerCAInjector:
-                description: CertManagerCAInjector includes spec for cert-manager-cainjector
-                  workload
-                properties:
-                  resources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                    type: object
-                type: object
-              certManagerController:
-                description: CertManagerController includes spec for cert-manager-controller
-                  workload
-                properties:
-                  resources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                    type: object
-                type: object
-              certManagerWebhook:
-                description: CertManagerWebhook includes spec for cert-manager-webhook
-                  workload
-                properties:
-                  resources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                    type: object
-                type: object
-              configMapWatcher:
-                description: ConfigMapWatcher includes spec for icp-configmap-watcher
-                  workload
-                properties:
-                  resources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                    type: object
-                type: object
-              disableHostNetwork:
-                type: boolean
-              enableCertRefresh:
-                description: EnableCertRefresh is a flag that can be set to enable
-                  the refresh of leaf certificates based on a root CA
-                type: boolean
-              enableWebhook:
-                type: boolean
-              imagePostFix:
-                type: string
-              imageRegistry:
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "operator-sdk generate k8s" to regenerate code after
-                  modifying this file Add custom validation using kubebuilder tags:
-                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-                type: string
-              refreshCertsBasedOnCA:
-                description: RefreshCertsBasedOnCA is a list of CA certificate names.
-                  Leaf certificates created from the CA will be refreshed when the
-                  CA is refreshed.
-                items:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: CertManager is the Schema for the certmanagers API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CertManagerSpec defines the desired state of CertManager
+              properties:
+                certManagerCAInjector:
+                  description: CertManagerCAInjector includes spec for cert-manager-cainjector workload
                   properties:
-                    certName:
-                      type: string
-                    namespace:
-                      type: string
-                  required:
-                  - certName
-                  - namespace
+                    resources:
+                      description: ResourceRequirements describes the compute resource requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
                   type: object
-                type: array
-              resourceNamespace:
-                type: string
-              version:
-                type: string
-            type: object
-          status:
-            description: CertManagerStatus defines the observed state of CertManager
-            properties:
-              certManagerStatus:
-                description: It will be as "OK when all objects are created successfully
-                type: string
-            required:
-            - certManagerStatus
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                certManagerController:
+                  description: CertManagerController includes spec for cert-manager-controller workload
+                  properties:
+                    resources:
+                      description: ResourceRequirements describes the compute resource requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                  type: object
+                certManagerWebhook:
+                  description: CertManagerWebhook includes spec for cert-manager-webhook workload
+                  properties:
+                    resources:
+                      description: ResourceRequirements describes the compute resource requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                  type: object
+                configMapWatcher:
+                  description: ConfigMapWatcher includes spec for icp-configmap-watcher workload
+                  properties:
+                    resources:
+                      description: ResourceRequirements describes the compute resource requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                  type: object
+                disableHostNetwork:
+                  type: boolean
+                enableCertRefresh:
+                  description: EnableCertRefresh is a flag that can be set to enable the refresh of leaf certificates based on a root CA
+                  type: boolean
+                enableWebhook:
+                  type: boolean
+                imagePostFix:
+                  type: string
+                imageRegistry:
+                  description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                  type: string
+                refreshCertsBasedOnCA:
+                  description: RefreshCertsBasedOnCA is a list of CA certificate names. Leaf certificates created from the CA will be refreshed when the CA is refreshed.
+                  items:
+                    properties:
+                      certName:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                      - certName
+                      - namespace
+                    type: object
+                  type: array
+                resourceNamespace:
+                  type: string
+                version:
+                  type: string
+              type: object
+            status:
+              description: CertManagerStatus defines the observed state of CertManager
+              properties:
+                certManagerStatus:
+                  description: It will be as "OK when all objects are created successfully
+                  type: string
+              required:
+                - certManagerStatus
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -267,6 +267,9 @@ rules:
   - challenges/status
   - orders/status
   - issuers/status
+  - issuers/finalizers
+  - clusterissuers/finalizers
+  - certificaterequests/finalizers
   - clusterissuers/status
   - certificates/finalizers
   - challenges/finalizers

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -115,12 +115,14 @@ rules:
   - clusterroles
   - clusterrolebindings
   - rolebindings
+  - roles
   verbs:
   - create
   - get
   - list
   - watch
   - delete
+  - update
 # operator deploys cert-manager-webhook apiservice
 - apiGroups:
   - apiregistration.k8s.io
@@ -156,6 +158,10 @@ rules:
   - cert-manager.io
   resources:
   - certificates
+  - certificaterequests
+  - orders
+  - challenges
+  - clusterissuers
   - issuers
   verbs:
   - create
@@ -165,7 +171,54 @@ rules:
   - patch
   - update
   - watch
-
+  - deletecollection
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - signers
+  verbs:
+  - approve
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - signers
+  verbs:
+  - sign
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/status
+  verbs:
+  - update
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - acme.cert-manager.io
+  resources:
+  - orders
+  - challenges
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - deletecollection
 - apiGroups:
   - certmanager.k8s.io
   resources:
@@ -183,6 +236,29 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates/status
+  - certificaterequests/status
+  - issuers/status
+  - clusterissuers/status
+  - certificates/finalizers
+  - certificaterequests/finalizers
+  - issuers/finalizers
+  - clusterissuers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - acme.cert-manager.io
+  resources:
+  - challenges/status
+  - orders/status
+  - challenges/finalizers
+  - orders/finalizers
+  verbs:
+  - update
 - apiGroups:
   - certmanager.k8s.io
   resources:
@@ -194,7 +270,6 @@ rules:
   - clusterissuers/status
   - certificates/finalizers
   - challenges/finalizers
-  - ingresses/finalizers
   - orders/finalizers
   verbs:
   - update
@@ -238,11 +313,34 @@ rules:
   - watch
   - create
   - delete
+- apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - gateways
+  - httproutes
+  - gateways/finalizers
+  - httproutes/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+
 # cert-manager service needs this to support inject ca bundle injection in ingresses
 - apiGroups:
-  - extensions
+  - networking.k8s.io
   resources:
   - ingresses
+  - ingresses/finalizers
   verbs:
   - get
   - list
@@ -355,20 +453,8 @@ rules:
 
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
-  resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"]
+  resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core", "cert-manager-controller"]
   verbs: ["get", "update", "patch"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["create"]
-
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - roles
-  - rolebindings
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - delete

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -344,3 +344,31 @@ rules:
   - get
   - list
   - watch
+
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "create", "update", "patch"]
+
+- apiGroups: ["auditregistration.k8s.io"]
+  resources: ["auditsinks"]
+  verbs: ["get", "list", "watch", "update"]
+
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"]
+  verbs: ["get", "update", "patch"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["create"]
+
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete

--- a/pkg/controller/certificate/certificate_controller.go
+++ b/pkg/controller/certificate/certificate_controller.go
@@ -121,6 +121,9 @@ func (r *ReconcileCertificate) Reconcile(request reconcile.Request) (reconcile.R
 	reqLogger.Info("### DEBUG ### Creating v1 Certificate", "Certificate.Namespace", instance.Namespace, "Certificate.Name", instance.Name)
 
 	annotations := instance.Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
 	annotations["ibm-cert-manager-operator-generated"] = "true"
 
 	certificate := certmanagerv1.Certificate{

--- a/pkg/controller/certmanager/deploys.go
+++ b/pkg/controller/certmanager/deploys.go
@@ -88,6 +88,7 @@ func deployLogic(instance *operatorv1alpha1.CertManager, client client.Client, k
 		if !equalDeploys(deployment, existingDeploy) {
 			// Update
 			log.V(2).Info("Updating deployment")
+			deployment.SetResourceVersion(existingDeploy.GetResourceVersion())
 			if err := client.Update(context.Background(), &deployment); err != nil {
 				return err
 			}
@@ -122,11 +123,9 @@ func setupDeploy(instance *operatorv1alpha1.CertManager, deploy *appsv1.Deployme
 			resourceNS = "--cluster-resource-namespace=" + instance.Spec.ResourceNS
 		}
 		var leaderElect = "--leader-election-namespace=" + ns
-		var webhookNS = "--webhook-namespace=" + ns
-		var webhookDNS = "--webhook-dns-names=cert-manager-webhook,cert-manager-webhook." + ns + ",cert-manager-webhook." + ns + ".svc"
 		var args = make([]string, len(res.DefaultArgs))
 		copy(args, res.DefaultArgs)
-		args = append(args, acmesolver, resourceNS, leaderElect, webhookNS, webhookDNS)
+		args = append(args, acmesolver, resourceNS, leaderElect)
 		returningDeploy.Spec.Template.Spec.Containers[0].Args = args
 		log.V(3).Info("The args", "args", deploy.Spec.Template.Spec.Containers[0].Args)
 

--- a/pkg/controller/certmanager/prereqs.go
+++ b/pkg/controller/certmanager/prereqs.go
@@ -49,8 +49,14 @@ func roles(instance *operatorv1alpha1.CertManager, scheme *runtime.Scheme, clien
 	if clusterRoleErr := createClusterRole(instance, scheme, client); clusterRoleErr != nil {
 		return clusterRoleErr
 	}
+	if roleErr := createRole(instance, scheme, client); roleErr != nil {
+		return roleErr
+	}
 	if clusterRoleBindingErr := createClusterRoleBinding(instance, scheme, client, ns); clusterRoleBindingErr != nil {
 		return clusterRoleBindingErr
+	}
+	if roleBindingErr := createRB(instance, scheme, client, ns); roleBindingErr != nil {
+		return roleBindingErr
 	}
 	if serviceAccountErr := createServiceAccount(instance, scheme, client, ns); serviceAccountErr != nil {
 		return serviceAccountErr
@@ -58,38 +64,88 @@ func roles(instance *operatorv1alpha1.CertManager, scheme *runtime.Scheme, clien
 	return nil
 }
 
-func createClusterRole(instance *operatorv1alpha1.CertManager, scheme *runtime.Scheme, client client.Client) error {
-	log.V(2).Info("Creating cluster role")
-	clusterRole := &rbacv1.ClusterRole{}
-	err := client.Get(context.Background(), types.NamespacedName{Name: res.ClusterRoleName, Namespace: ""}, clusterRole)
-	if err != nil && apiErrors.IsNotFound(err) {
-		res.DefaultClusterRole.ResourceVersion = ""
-
-		if err := controllerutil.SetControllerReference(instance, res.DefaultClusterRole, scheme); err != nil {
-			log.Error(err, "Error setting controller reference on clusterrole")
+func createRole(instance *operatorv1alpha1.CertManager, scheme *runtime.Scheme, client client.Client) error {
+	log.V(0).Info("Creating roles")
+	for _, r := range res.RolesToCreate.Items {
+		log.V(0).Info("Creating role " + r.Name)
+		role := &rbacv1.Role{}
+		err := client.Get(context.Background(), types.NamespacedName{Name: r.Name, Namespace: r.Namespace}, role)
+		if err != nil && apiErrors.IsNotFound(err) {
+			r.ResourceVersion = ""
+			if err := controllerutil.SetControllerReference(instance, &r, scheme); err != nil {
+				log.Error(err, "Error setting controller reference on role")
+			}
+			err := client.Create(context.Background(), &r)
+			if err != nil {
+				return err
+			}
 		}
-		err := client.Create(context.Background(), res.DefaultClusterRole)
-		if err != nil {
-			return err
+	}
+	return nil
+}
+
+func createClusterRole(instance *operatorv1alpha1.CertManager, scheme *runtime.Scheme, client client.Client) error {
+	log.V(0).Info("Creating cluster roles")
+	for _, r := range res.ClusterRolesToCreate.Items {
+		log.V(0).Info("Creating cluster role " + r.Name)
+		clusterRole := &rbacv1.ClusterRole{}
+		err := client.Get(context.Background(), types.NamespacedName{Name: r.Name, Namespace: ""}, clusterRole)
+		if err != nil && apiErrors.IsNotFound(err) {
+			r.ResourceVersion = ""
+
+			if err := controllerutil.SetControllerReference(instance, &r, scheme); err != nil {
+				log.Error(err, "Error setting controller reference on clusterrole")
+			}
+			err := client.Create(context.Background(), &r)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil
 }
 
 func createClusterRoleBinding(instance *operatorv1alpha1.CertManager, scheme *runtime.Scheme, client client.Client, namespace string) error {
-	log.V(2).Info("Creating cluster role binding")
-	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+	log.V(0).Info("Creating cluster role binding")
+	for _, b := range res.ClusterRoleBindingsToCreate.Items {
+		log.V(0).Info("Creating cluster role binding " + b.Name)
+		clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 
-	err := client.Get(context.Background(), types.NamespacedName{Name: res.ClusterRoleName, Namespace: ""}, clusterRoleBinding)
-	if err != nil && apiErrors.IsNotFound(err) {
-		res.DefaultClusterRoleBinding.ResourceVersion = ""
-		res.DefaultClusterRoleBinding.Subjects[0].Namespace = namespace
-		if err := controllerutil.SetControllerReference(instance, res.DefaultClusterRoleBinding, scheme); err != nil {
-			log.Error(err, "Error setting controller reference on clusterrolebinding")
+		err := client.Get(context.Background(), types.NamespacedName{Name: b.Name, Namespace: ""}, clusterRoleBinding)
+		if err != nil && apiErrors.IsNotFound(err) {
+			b.ResourceVersion = ""
+			b.Subjects[0].Namespace = namespace
+			if err := controllerutil.SetControllerReference(instance, &b, scheme); err != nil {
+				log.Error(err, "Error setting controller reference on clusterrolebinding")
+			}
+			err := client.Create(context.Background(), &b)
+			if err != nil {
+				return err
+			}
 		}
-		err := client.Create(context.Background(), res.DefaultClusterRoleBinding)
-		if err != nil {
-			return err
+	}
+
+	return nil
+}
+
+// TODO: rename this to createRoleBinding after refactoring the existing createRoleBinding in prereqs-webhook.go
+func createRB(instance *operatorv1alpha1.CertManager, scheme *runtime.Scheme, client client.Client, namespace string) error {
+	log.V(0).Info("Creating role binding")
+	for _, b := range res.RoleBindingsToCreate.Items {
+		log.V(0).Info("Creating role binding " + b.Name)
+		roleBinding := &rbacv1.RoleBinding{}
+
+		err := client.Get(context.Background(), types.NamespacedName{Name: b.Name, Namespace: b.Namespace}, roleBinding)
+		if err != nil && apiErrors.IsNotFound(err) {
+			b.ResourceVersion = ""
+			b.Subjects[0].Namespace = namespace
+			if err := controllerutil.SetControllerReference(instance, &b, scheme); err != nil {
+				log.Error(err, "Error setting controller reference on rolebinding")
+			}
+			err := client.Create(context.Background(), &b)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -97,17 +153,20 @@ func createClusterRoleBinding(instance *operatorv1alpha1.CertManager, scheme *ru
 }
 
 func createServiceAccount(instance *operatorv1alpha1.CertManager, scheme *runtime.Scheme, client client.Client, namespace string) error {
-	log.V(2).Info("Creating service account")
-	res.DefaultServiceAccount.ResourceVersion = ""
-	res.DefaultServiceAccount.Namespace = namespace
-	err := client.Create(context.Background(), res.DefaultServiceAccount)
-	if err := controllerutil.SetControllerReference(instance, res.DefaultServiceAccount, scheme); err != nil {
-		log.Error(err, "Error setting controller reference on service account")
-	}
-	if err != nil {
-		if !apiErrors.IsAlreadyExists(err) {
-			log.V(2).Info("Error creating the service account, but was not an already exists error", "error message", err)
-			return err
+	log.V(0).Info("Creating service account")
+	for _, a := range res.ServiceAccountsToCreate.Items {
+		log.V(0).Info("Creating service account" + a.Name)
+		a.ResourceVersion = ""
+		a.Namespace = namespace
+		err := client.Create(context.Background(), &a)
+		if err := controllerutil.SetControllerReference(instance, &a, scheme); err != nil {
+			log.Error(err, "Error setting controller reference on service account")
+		}
+		if err != nil {
+			if !apiErrors.IsAlreadyExists(err) {
+				log.V(2).Info("Error creating the service account, but was not an already exists error", "error message", err)
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/controller/issuer/issuer_controller.go
+++ b/pkg/controller/issuer/issuer_controller.go
@@ -120,6 +120,9 @@ func (r *ReconcileIssuer) Reconcile(request reconcile.Request) (reconcile.Result
 	reqLogger.Info("### DEBUG ### Creating v1 Issuer", "Issuer.Namespace", instance.Namespace, "Issuer.Name", instance.Name)
 
 	annotations := instance.Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
 	annotations["ibm-cert-manager-operator-generated"] = "true"
 
 	v1Issuer := certmanagerv1.Issuer{

--- a/pkg/controller/issuer/issuer_controller.go
+++ b/pkg/controller/issuer/issuer_controller.go
@@ -19,19 +19,21 @@ package issuer
 import (
 	"context"
 
-	certmanagerv1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1"
-	certmanagerv1alpha1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	certmanagerv1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1"
+	certmanagerv1alpha1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1alpha1"
 )
 
 var log = logf.Log.WithName("controller_issuer")
@@ -68,7 +70,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// TODO(user): Modify this to be the types you create that are owned by the primary resource
 	// Watch for changes to secondary resource Pods and requeue the owner Issuer
-	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
+	err = c.Watch(&source.Kind{Type: &certmanagerv1.Issuer{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &certmanagerv1alpha1.Issuer{},
 	})
@@ -125,17 +127,16 @@ func (r *ReconcileIssuer) Reconcile(request reconcile.Request) (reconcile.Result
 	}
 	annotations["ibm-cert-manager-operator-generated"] = "true"
 
-	v1Issuer := certmanagerv1.Issuer{
+	v1Issuer := &certmanagerv1.Issuer{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Issuer",
 			APIVersion: "cert-manager.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            instance.Name,
-			Namespace:       instance.Namespace,
-			Labels:          instance.Labels,
-			Annotations:     annotations,
-			OwnerReferences: instance.OwnerReferences,
+			Name:        instance.Name,
+			Namespace:   instance.Namespace,
+			Labels:      instance.Labels,
+			Annotations: annotations,
 		},
 		Spec: certmanagerv1.IssuerSpec{
 			IssuerConfig: certmanagerv1.IssuerConfig{
@@ -144,10 +145,28 @@ func (r *ReconcileIssuer) Reconcile(request reconcile.Request) (reconcile.Result
 		},
 	}
 
-	if err := r.client.Create(context.TODO(), &v1Issuer); err != nil {
+	// Set the issuer v1alpha1 as the controller of the issuer v1
+	if err := controllerutil.SetControllerReference(instance, v1Issuer, r.scheme); err != nil {
+		reqLogger.Error(err, "### DEBUG ### failed to set owner reference for %s", v1Issuer)
+		return reconcile.Result{}, err
+	}
+
+	if err := r.client.Create(context.TODO(), v1Issuer); err != nil {
 		if errors.IsAlreadyExists(err) {
-			reqLogger.Error(err, "### DEBUG ### v1 Issuer already exists")
-			return reconcile.Result{}, nil
+			existingIssuer := &certmanagerv1.Issuer{}
+			if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: v1Issuer.Namespace, Name: v1Issuer.Name}, existingIssuer); err != nil {
+				reqLogger.Error(err, "### DEBUG ### Failed to get v1 Issuer")
+				return reconcile.Result{}, err
+			} else {
+				v1Issuer.SetResourceVersion(existingIssuer.GetResourceVersion())
+				if err := r.client.Update(context.TODO(), v1Issuer); err != nil {
+					reqLogger.Error(err, "### DEBUG ### Failed to update v1 Issuer")
+					return reconcile.Result{}, err
+				} else {
+					reqLogger.Info("### DEBUG #### Updated v1 Issuer")
+					return reconcile.Result{}, nil
+				}
+			}
 		}
 		reqLogger.Error(err, "### DEBUG ### Failed to create v1 Issuer")
 		return reconcile.Result{}, err

--- a/pkg/resources/constants.go
+++ b/pkg/resources/constants.go
@@ -242,16 +242,8 @@ const leaderElectNS = "--leader-election-namespace=cert-manager"
 // AcmeSolverArg is the acme solver image to use for the cert-manager-controller
 var AcmeSolverArg = "--acme-http01-solver-image=" + acmesolverImage
 
-var webhookNSArg = "--webhook-namespace=" + DeployNamespace
-
-const webhookCASecretArg = "--webhook-ca-secret=cert-manager-webhook-ca"
-const webhookServingSecretArg = "--webhook-serving-secret=" + WebhookServingSecret
-
-const webhookDNSNamesArg = "--webhook-dns-names=cert-manager-webhook,cert-manager-webhook.cert-manager,cert-manager-webhook.cert-manager.svc"
-const controllersArg = "--controllers=certificates,issuers,clusterissuers,orders,challenges,webhook-bootstrap"
-
 // DefaultArgs are the default arguments use for cert-manager-controller
-var DefaultArgs = []string{webhookCASecretArg, webhookServingSecretArg, controllersArg}
+var DefaultArgs = []string{}
 
 // CRDs is the list of crds created/used by cert-manager in this version
 var CRDs = [5]string{"certificates", "issuers", "clusterissuers", "orders", "challenges"}

--- a/pkg/resources/containers.go
+++ b/pkg/resources/containers.go
@@ -58,7 +58,7 @@ var controllerContainer = corev1.Container{
 	Name:            CertManagerControllerName,
 	Image:           controllerImage,
 	ImagePullPolicy: pullPolicy,
-	Args:            []string{leaderElectNS, webhookNSArg, webhookCASecretArg, webhookServingSecretArg, webhookDNSNamesArg},
+	Args:            []string{leaderElectNS},
 	Env: []corev1.EnvVar{
 		{
 			Name: "POD_NAMESPACE",

--- a/pkg/resources/pods.go
+++ b/pkg/resources/pods.go
@@ -77,7 +77,7 @@ var certManagerWebhookPod = corev1.PodSpec{
 
 var certManagerCainjectorPod = corev1.PodSpec{
 	Affinity:           podAffinity,
-	ServiceAccountName: ServiceAccount,
+	ServiceAccountName: "ibm-cert-manager-cainjector",
 	SecurityContext:    podSecurity,
 	Containers: []corev1.Container{
 		cainjectorContainer,

--- a/pkg/resources/pods.go
+++ b/pkg/resources/pods.go
@@ -48,7 +48,7 @@ var podSecurity = &corev1.PodSecurityContext{
 
 var certManagerControllerPod = corev1.PodSpec{
 	Affinity:           podAffinity,
-	ServiceAccountName: ServiceAccount,
+	ServiceAccountName: "ibm-cert-manager-controller",
 	SecurityContext:    podSecurity,
 	Containers: []corev1.Container{
 		controllerContainer,

--- a/pkg/resources/rbac.go
+++ b/pkg/resources/rbac.go
@@ -22,6 +22,26 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var ServiceAccountsToCreate = &corev1.ServiceAccountList{
+	Items: []corev1.ServiceAccount{*DefaultServiceAccount, *CAInjectorServiceAccount},
+}
+
+var RolesToCreate = &rbacv1.RoleList{
+	Items: []rbacv1.Role{*CAInjectorRole},
+}
+
+var RoleBindingsToCreate = &rbacv1.RoleBindingList{
+	Items: []rbacv1.RoleBinding{*CAInjectorRoleBinding},
+}
+
+var ClusterRolesToCreate = &rbacv1.ClusterRoleList{
+	Items: []rbacv1.ClusterRole{*DefaultClusterRole, *CAInjectorClusterRole},
+}
+
+var ClusterRoleBindingsToCreate = &rbacv1.ClusterRoleBindingList{
+	Items: []rbacv1.ClusterRoleBinding{*DefaultClusterRoleBinding, *CAInjectorClusterRoleBinding},
+}
+
 // DefaultServiceAccount is the service account used by cert-manager service
 var DefaultServiceAccount = &corev1.ServiceAccount{
 	ObjectMeta: metav1.ObjectMeta{
@@ -133,6 +153,121 @@ var DefaultClusterRoleBinding = &rbacv1.ClusterRoleBinding{
 		APIGroup: "rbac.authorization.k8s.io",
 		Kind:     "ClusterRole",
 		Name:     ClusterRoleName,
+	},
+}
+
+var CAInjectorServiceAccount = &corev1.ServiceAccount{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-cainjector",
+	},
+}
+
+var CAInjectorRole = &rbacv1.Role{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "ibm-cert-manager-cainjector:leaderelection",
+		Namespace: "ibm-common-services",
+	},
+	Rules: []rbacv1.PolicyRule{
+		{
+			Verbs:         []string{"get", "update", "patch"},
+			APIGroups:     []string{""},
+			Resources:     []string{"configmaps"},
+			ResourceNames: []string{"cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"},
+		},
+		{
+			Verbs:     []string{"create"},
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+		},
+		{
+			Verbs:         []string{"get", "update", "patch"},
+			APIGroups:     []string{"coordination.k8s.io"},
+			Resources:     []string{"leases"},
+			ResourceNames: []string{"cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"},
+		},
+		{
+			Verbs:     []string{"create"},
+			APIGroups: []string{"coordination.k8s.io"},
+			Resources: []string{"leases"},
+		},
+	},
+}
+
+var CAInjectorRoleBinding = &rbacv1.RoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "ibm-cert-manager-cainjector:leaderelection",
+		Namespace: "ibm-common-services",
+	},
+	Subjects: []rbacv1.Subject{
+		{
+			Kind: "ServiceAccount",
+			Name: "ibm-cert-manager-cainjector",
+		},
+	},
+	RoleRef: rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "Role",
+		Name:     "ibm-cert-manager-cainjector:leaderelection",
+	},
+}
+
+var CAInjectorClusterRole = &rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-cainjector",
+	},
+	Rules: []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{"cert-manager.io"},
+			Resources: []string{"certificates"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+		},
+		{
+			Verbs:     []string{"get", "create", "update", "patch"},
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch", "update"},
+			APIGroups: []string{"admissionregistration.k8s.io"},
+			Resources: []string{"validatingwebhookconfigurations", "mutatingwebhookconfigurations"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch", "update"},
+			APIGroups: []string{"apiregistration.k8s.io"},
+			Resources: []string{"apiservices"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch", "update"},
+			APIGroups: []string{"apiextensions.k8s.io"},
+			Resources: []string{"customresourcedefinitions"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch", "update"},
+			APIGroups: []string{"auditregistration.k8s.io"},
+			Resources: []string{"auditsinks"},
+		},
+	},
+}
+
+var CAInjectorClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-cainjector",
+	},
+	Subjects: []rbacv1.Subject{
+		{
+			Kind: "ServiceAccount",
+			Name: "ibm-cert-manager-cainjector",
+		},
+	},
+	RoleRef: rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "ClusterRole",
+		Name:     "ibm-cert-manager-cainjector",
 	},
 }
 

--- a/pkg/resources/rbac.go
+++ b/pkg/resources/rbac.go
@@ -23,64 +23,431 @@ import (
 )
 
 var ServiceAccountsToCreate = &corev1.ServiceAccountList{
-	Items: []corev1.ServiceAccount{*DefaultServiceAccount, *CAInjectorServiceAccount},
+	Items: []corev1.ServiceAccount{*ControllerServiceAccount, *CAInjectorServiceAccount},
 }
 
 var RolesToCreate = &rbacv1.RoleList{
-	Items: []rbacv1.Role{*CAInjectorRole},
+	Items: []rbacv1.Role{*ControllerRole, *CAInjectorRole},
 }
 
 var RoleBindingsToCreate = &rbacv1.RoleBindingList{
-	Items: []rbacv1.RoleBinding{*CAInjectorRoleBinding},
+	Items: []rbacv1.RoleBinding{*ControllerRoleBinding, *CAInjectorRoleBinding},
 }
 
 var ClusterRolesToCreate = &rbacv1.ClusterRoleList{
-	Items: []rbacv1.ClusterRole{*DefaultClusterRole, *CAInjectorClusterRole},
+	Items: []rbacv1.ClusterRole{*ControllerViewClusterRole, *ControllerEditClusterRole, *ControllerApproveClusterRole, *ControllerCertificateSigningRequestsClusterRole, *ControllerIssuersClusterRole, *ControllerClusterIssuersClusterRole, *ControllerCertificatesClusterRole, *ControllerOrdersClusterRole, *ControllerChallengesClusterRole, *ControllerIngressShimClusterRole, *CAInjectorClusterRole},
 }
 
 var ClusterRoleBindingsToCreate = &rbacv1.ClusterRoleBindingList{
-	Items: []rbacv1.ClusterRoleBinding{*DefaultClusterRoleBinding, *CAInjectorClusterRoleBinding},
+	Items: []rbacv1.ClusterRoleBinding{*ControllerApproveClusterRoleBinding, *ControllerCertificateSigningRequestsClusterRoleBinding, *ControllerIssuersClusterRoleBinding, *ControllerClusterIssuersClusterRoleBinding, *ControllerCertificatesClusterRoleBinding, *ControllerOrdersClusterRoleBinding, *ControllerChallengesClusterRoleBinding, *ControllerIngressShimClusterRoleBinding, *CAInjectorClusterRoleBinding},
 }
 
-// DefaultServiceAccount is the service account used by cert-manager service
-var DefaultServiceAccount = &corev1.ServiceAccount{
+var ControllerServiceAccount = &corev1.ServiceAccount{
 	ObjectMeta: metav1.ObjectMeta{
-		Name: ServiceAccount,
-		//		Namespace: DeployNamespace,
+		Name: "ibm-cert-manager-controller",
 	},
 }
 
-// DefaultClusterRole is the cluster role used by cert-manager service
-var DefaultClusterRole = &rbacv1.ClusterRole{
+var ControllerRole = &rbacv1.Role{
 	ObjectMeta: metav1.ObjectMeta{
-		Name: ClusterRoleName,
+		Name:      "ibm-cert-manager-controller:leaderelection",
+		Namespace: "ibm-common-services",
 	},
 	Rules: []rbacv1.PolicyRule{
 		{
-			Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
-			APIGroups: []string{""},
-			Resources: []string{"secrets", "configmaps"},
+			Verbs:         []string{"get", "update", "patch"},
+			APIGroups:     []string{""},
+			Resources:     []string{"configmaps"},
+			ResourceNames: []string{"cert-manager-controller"},
 		},
 		{
-			Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-			APIGroups: []string{"certmanager.k8s.io"},
-			Resources: []string{"certificates", "issuers", "clusterissuers", "orders", "challenges"},
+			Verbs:     []string{"create"},
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+		},
+		{
+			Verbs:         []string{"get", "update", "patch"},
+			APIGroups:     []string{"coordination.k8s.io"},
+			Resources:     []string{"leases"},
+			ResourceNames: []string{"cert-manager-controller"},
+		},
+		{
+			Verbs:     []string{"create"},
+			APIGroups: []string{"coordination.k8s.io"},
+			Resources: []string{"leases"},
+		},
+	},
+}
+
+var ControllerRoleBinding = &rbacv1.RoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "ibm-cert-manager-controller:leaderelection",
+		Namespace: "ibm-common-services",
+	},
+	Subjects: []rbacv1.Subject{
+		{
+			Kind: "ServiceAccount",
+			Name: "ibm-cert-manager-controller",
+		},
+	},
+	RoleRef: rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "Role",
+		Name:     "ibm-cert-manager-controller:leaderelection",
+	},
+}
+
+var ControllerViewClusterRole = &rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-view",
+		Labels: map[string]string{
+			"rbac.authorization.k8s.io/aggregate-to-view":  "true",
+			"rbac.authorization.k8s.io/aggregate-to-edit":  "true",
+			"rbac.authorization.k8s.io/aggregate-to-admin": "true",
+		},
+	},
+	Rules: []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{"cert-manager.io"},
+			Resources: []string{"certificates", "certificaterequests", "issuers"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{"acme.cert-manager.io"},
+			Resources: []string{"challenges", "orders"},
+		},
+	},
+}
+
+var ControllerEditClusterRole = &rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-edit",
+		Labels: map[string]string{
+			"rbac.authorization.k8s.io/aggregate-to-edit":  "true",
+			"rbac.authorization.k8s.io/aggregate-to-admin": "true",
+		},
+	},
+	Rules: []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"create", "delete", "deletecollection", "patch", "update"},
+			APIGroups: []string{"cert-manager.io"},
+			Resources: []string{"certificates", "certificaterequests", "issuers"},
+		},
+		{
+			Verbs:     []string{"create", "delete", "deletecollection", "patch", "update"},
+			APIGroups: []string{"acme.cert-manager.io"},
+			Resources: []string{"challenges", "orders"},
+		},
+	},
+}
+
+var ControllerApproveClusterRole = &rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-approve:cert-manager-io",
+	},
+	Rules: []rbacv1.PolicyRule{
+		{
+			Verbs:         []string{"approve"},
+			APIGroups:     []string{"cert-manager.io"},
+			Resources:     []string{"signers"},
+			ResourceNames: []string{"issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"},
+		},
+	},
+}
+
+var ControllerApproveClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-approve:cert-manager-io",
+	},
+	Subjects: []rbacv1.Subject{
+		{
+			Kind: "ServiceAccount",
+			Name: "ibm-cert-manager-controller",
+		},
+	},
+	RoleRef: rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "ClusterRole",
+		Name:     "ibm-cert-manager-controller-approve:cert-manager-io",
+	},
+}
+
+var ControllerCertificateSigningRequestsClusterRole = &rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-certificatesigningrequests",
+	},
+	Rules: []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"get", "list", "watch", "update"},
+			APIGroups: []string{"certificates.k8s.io"},
+			Resources: []string{"certificatesigningrequests"},
 		},
 		{
 			Verbs:     []string{"update"},
-			APIGroups: []string{"certmanager.k8s.io"},
-			Resources: []string{
-				"certificates/status",
-				"certificaterequests/status",
-				"challenges/status",
-				"clusterissuers/status",
-				"issuers/status",
-				"orders/status",
-				"certificates/finalizers",
-				"challenges/finalizers",
-				"ingresses/finalizers",
-				"orders/finalizers",
-			},
+			APIGroups: []string{"certificates.k8s.io"},
+			Resources: []string{"certificatesigningrequests/status"},
+		},
+		{
+			Verbs:         []string{"sign"},
+			APIGroups:     []string{"certificates.k8s.io"},
+			Resources:     []string{"signers"},
+			ResourceNames: []string{"issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"},
+		},
+		{
+			Verbs:     []string{"create"},
+			APIGroups: []string{"authorization.k8s.io"},
+			Resources: []string{"subjectaccessreviews"},
+		},
+	},
+}
+
+var ControllerCertificateSigningRequestsClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-certificatesigningrequests",
+	},
+	Subjects: []rbacv1.Subject{
+		{
+			Kind: "ServiceAccount",
+			Name: "ibm-cert-manager-controller",
+		},
+	},
+	RoleRef: rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "ClusterRole",
+		Name:     "ibm-cert-manager-controller-certificatesigningrequests",
+	},
+}
+
+var ControllerIssuersClusterRole = &rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-issuers",
+	},
+	Rules: []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"update"},
+			APIGroups: []string{"cert-manager.io"},
+			Resources: []string{"issuers", "issuers/status"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{"cert-manager.io"},
+			Resources: []string{"issuers"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+		},
+		{
+			Verbs:     []string{"create", "patch"},
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+		},
+	},
+}
+
+var ControllerIssuersClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-issuers",
+	},
+	Subjects: []rbacv1.Subject{
+		{
+			Kind: "ServiceAccount",
+			Name: "ibm-cert-manager-controller",
+		},
+	},
+	RoleRef: rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "ClusterRole",
+		Name:     "ibm-cert-manager-controller-issuers",
+	},
+}
+
+var ControllerClusterIssuersClusterRole = &rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-clusterissuers",
+	},
+	Rules: []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"update"},
+			APIGroups: []string{"cert-manager.io"},
+			Resources: []string{"clusterissuers", "clusterissuers/status"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{"cert-manager.io"},
+			Resources: []string{"clusterissuers"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+		},
+		{
+			Verbs:     []string{"create", "patch"},
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+		},
+	},
+}
+
+var ControllerClusterIssuersClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-clusterissuers",
+	},
+	Subjects: []rbacv1.Subject{
+		{
+			Kind: "ServiceAccount",
+			Name: "ibm-cert-manager-controller",
+		},
+	},
+	RoleRef: rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "ClusterRole",
+		Name:     "ibm-cert-manager-controller-clusterissuers",
+	},
+}
+
+var ControllerCertificatesClusterRole = &rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-certificates",
+	},
+	Rules: []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"update"},
+			APIGroups: []string{"cert-manager.io"},
+			Resources: []string{"certificates", "certificates/status", "certificaterequests", "certificaterequests/status"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{"cert-manager.io"},
+			Resources: []string{"certificates", "certificaterequests", "clusterissuers", "issuers"},
+		},
+		{
+			Verbs:     []string{"update"},
+			APIGroups: []string{"cert-manager.io"},
+			Resources: []string{"certificates/finalizers", "certificaterequests/finalizers"},
+		},
+		{
+			Verbs:     []string{"create", "delete", "get", "list", "watch"},
+			APIGroups: []string{"acme.cert-manager.io"},
+			Resources: []string{"orders"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+		},
+		{
+			Verbs:     []string{"create", "patch"},
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+		},
+	},
+}
+
+var ControllerCertificatesClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-certificates",
+	},
+	Subjects: []rbacv1.Subject{
+		{
+			Kind: "ServiceAccount",
+			Name: "ibm-cert-manager-controller",
+		},
+	},
+	RoleRef: rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "ClusterRole",
+		Name:     "ibm-cert-manager-controller-certificates",
+	},
+}
+
+var ControllerOrdersClusterRole = &rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-orders",
+	},
+	Rules: []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"update"},
+			APIGroups: []string{"acme.cert-manager.io"},
+			Resources: []string{"orders", "orders/status"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{"acme.cert-manager.io"},
+			Resources: []string{"orders", "challenges"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{"cert-manager.io"},
+			Resources: []string{"clusterissuers", "issuers"},
+		},
+		{
+			Verbs:     []string{"create", "delete"},
+			APIGroups: []string{"acme.cert-manager.io"},
+			Resources: []string{"challenges"},
+		},
+		{
+			Verbs:     []string{"update"},
+			APIGroups: []string{"acme.cert-manager.io"},
+			Resources: []string{"orders/finalizers"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+		},
+		{
+			Verbs:     []string{"create", "patch"},
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+		},
+	},
+}
+
+var ControllerOrdersClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-orders",
+	},
+	Subjects: []rbacv1.Subject{
+		{
+			Kind: "ServiceAccount",
+			Name: "ibm-cert-manager-controller",
+		},
+	},
+	RoleRef: rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "ClusterRole",
+		Name:     "ibm-cert-manager-controller-orders",
+	},
+}
+
+var ControllerChallengesClusterRole = &rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-challenges",
+	},
+	Rules: []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"update"},
+			APIGroups: []string{"acme.cert-manager.io"},
+			Resources: []string{"challenges", "challenges/status"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{"acme.cert-manager.io"},
+			Resources: []string{"challenges"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{"cert-manager.io"},
+			Resources: []string{"clusterissuers", "issuers"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
 		},
 		{
 			Verbs:     []string{"create", "patch"},
@@ -94,65 +461,106 @@ var DefaultClusterRole = &rbacv1.ClusterRole{
 		},
 		{
 			Verbs:     []string{"get", "list", "watch", "create", "delete", "update"},
-			APIGroups: []string{"extensions"},
+			APIGroups: []string{"networking.k8s.io"},
 			Resources: []string{"ingresses"},
 		},
 		{
-			Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-			APIGroups: []string{"apps"},
-			Resources: []string{"deployments", "statefulsets", "daemonsets"},
+			Verbs:     []string{"get", "list", "watch", "create", "delete", "update"},
+			APIGroups: []string{"networking.x-k8s.io"},
+			Resources: []string{"httproutes"},
 		},
 		{
-			Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-			APIGroups: []string{"apiextensions.k8s.io"},
-			Resources: []string{"customresourcedefinitions"},
+			Verbs:     []string{"create"},
+			APIGroups: []string{"route.openshift.io"},
+			Resources: []string{"routes/custom-host"},
 		},
 		{
-			Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-			APIGroups: []string{"admission.certmanager.k8s.io"},
-			Resources: []string{"certificates", "clusterissuers", "issuers", "certificaterequests"},
+			Verbs:     []string{"update"},
+			APIGroups: []string{"acme.cert-manager.io"},
+			Resources: []string{"challenges/finalizers"},
 		},
 		{
-			Verbs:         []string{"use"},
-			APIGroups:     []string{"security.openshift.io"},
-			Resources:     []string{"securitycontextconstraints"},
-			ResourceNames: []string{"restricted", "hostnetwork"},
-		},
-		{
-			Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-			APIGroups: []string{"admissionregistration.k8s.io"},
-			Resources: []string{"mutatingwebhookconfigurations", "validatingwebhookconfigurations"},
-		},
-		{
-			Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-			APIGroups: []string{"apiregistration.k8s.io"},
-			Resources: []string{"apiservices"},
-		},
-		{
-			Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-			APIGroups: []string{"authorization.k8s.io"},
-			Resources: []string{"subjectaccessreviews"},
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
 		},
 	},
 }
 
-// DefaultClusterRoleBinding the clusterrolebinding used by cert-manager service
-var DefaultClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+var ControllerChallengesClusterRoleBinding = &rbacv1.ClusterRoleBinding{
 	ObjectMeta: metav1.ObjectMeta{
-		Name: ClusterRoleName,
+		Name: "ibm-cert-manager-controller-challenges",
 	},
 	Subjects: []rbacv1.Subject{
 		{
-			Kind:     "ServiceAccount",
-			APIGroup: "",
-			Name:     ServiceAccount,
-			//			Namespace: DeployNamespace,
+			Kind: "ServiceAccount",
+			Name: "ibm-cert-manager-controller",
 		},
 	},
 	RoleRef: rbacv1.RoleRef{
 		APIGroup: "rbac.authorization.k8s.io",
 		Kind:     "ClusterRole",
-		Name:     ClusterRoleName,
+		Name:     "ibm-cert-manager-controller-challenges",
+	},
+}
+
+var ControllerIngressShimClusterRole = &rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-ingress-shim",
+	},
+	Rules: []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"create", "update", "delete"},
+			APIGroups: []string{"cert-manager.io"},
+			Resources: []string{"certificates", "certificaterequests"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{"cert-manager.io"},
+			Resources: []string{"certificates", "certificaterequests", "issuers", "clusterissuers"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{"networking.k8s.io"},
+			Resources: []string{"ingresses"},
+		},
+		{
+			Verbs:     []string{"update"},
+			APIGroups: []string{"networking.k8s.io"},
+			Resources: []string{"ingresses/finalizers"},
+		},
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{"networking.x-k8s.io"},
+			Resources: []string{"gateways", "httproutes"},
+		},
+		{
+			Verbs:     []string{"update"},
+			APIGroups: []string{"networking.x-k8s.io"},
+			Resources: []string{"gateways/finalizers", "httproutes/finalizers"},
+		},
+		{
+			Verbs:     []string{"create", "patch"},
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+		},
+	},
+}
+
+var ControllerIngressShimClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ibm-cert-manager-controller-ingress-shim",
+	},
+	Subjects: []rbacv1.Subject{
+		{
+			Kind: "ServiceAccount",
+			Name: "ibm-cert-manager-controller",
+		},
+	},
+	RoleRef: rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "ClusterRole",
+		Name:     "ibm-cert-manager-controller-ingress-shim",
 	},
 }
 
@@ -200,8 +608,9 @@ var CAInjectorRoleBinding = &rbacv1.RoleBinding{
 	},
 	Subjects: []rbacv1.Subject{
 		{
-			Kind: "ServiceAccount",
-			Name: "ibm-cert-manager-cainjector",
+			Kind:      "ServiceAccount",
+			Name:      "ibm-cert-manager-cainjector",
+			Namespace: DeployNamespace,
 		},
 	},
 	RoleRef: rbacv1.RoleRef{

--- a/pkg/resources/util.go
+++ b/pkg/resources/util.go
@@ -28,10 +28,8 @@ var log = logf.Log.WithName("resource_utils")
 //GetImageID constructs image IDs for operands: either <IMAGE_NAME>:<IMAGE_TAG> or <IMAGE_NAME>@<IMAGE_SHA>
 func GetImageID(imageRegistry, imageName, defaultImageVersion, imagePostfix, envVarName string) string {
 
-	var imageID string
-
 	//Check if the env var exists, if yes, check whether it's a SHA or tag and use accordingly; if no, use the default image version
-	imageID = os.Getenv(envVarName)
+	imageID := os.Getenv(envVarName)
 
 	if len(imageID) > 0 {
 		log.V(2).Info("Using env var for operand image: " + imageName)


### PR DESCRIPTION
Issue:  We can't inherit owner references from v1alpha1 cert-manager objects because we don't have the relevant permission to the parent resources of  v1alpha1 cert-manager objects.

This PR implements:
1. Set v0.10  cert manager CRs as the owner of v1.x  cert manager CRs
2. Enable update logic:  When v0.10  cert manager CRs are updated, v1.x  cert manager CRs will be updated as well

Need to consider:

1. Should we watch the change of v1.x  cert manager CRs and trigger the reconciliation for its owner? 