### PR TITLE
feat: Set v1alpha1 objects as the owner of v1 objects

### DIFF
--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/ibm-cert-manager-operator.v3.13.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/ibm-cert-manager-operator.v3.13.0.clusterserviceversion.yaml
@@ -397,6 +397,9 @@ spec:
               - orders/status
               - issuers/status
               - clusterissuers/status
+              - issuers/finalizers
+              - clusterissuers/finalizers
+              - certificaterequests/finalizers
               - certificates/finalizers
               - challenges/finalizers
               - orders/finalizers

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -267,6 +267,9 @@ rules:
   - challenges/status
   - orders/status
   - issuers/status
+  - issuers/finalizers
+  - clusterissuers/finalizers
+  - certificaterequests/finalizers
   - clusterissuers/status
   - certificates/finalizers
   - challenges/finalizers

--- a/pkg/controller/certificate/certificate_controller.go
+++ b/pkg/controller/certificate/certificate_controller.go
@@ -136,7 +136,6 @@ func (r *ReconcileCertificate) Reconcile(request reconcile.Request) (reconcile.R
 			Namespace:       instance.Namespace,
 			Labels:          instance.Labels,
 			Annotations:     annotations,
-			OwnerReferences: instance.OwnerReferences,
 		},
 		Spec: certmanagerv1.CertificateSpec{
 			CommonName: instance.Spec.CommonName,

--- a/pkg/controller/certificate/certificate_controller.go
+++ b/pkg/controller/certificate/certificate_controller.go
@@ -19,20 +19,22 @@ package certificate
 import (
 	"context"
 
-	certmanagerv1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1"
-	certmanagerv1alpha1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1alpha1"
 	cmmeta "github.com/ibm/ibm-cert-manager-operator/pkg/apis/meta/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	certmanagerv1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1"
+	certmanagerv1alpha1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1alpha1"
 )
 
 var log = logf.Log.WithName("controller_certificate")
@@ -69,7 +71,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// TODO(user): Modify this to be the types you create that are owned by the primary resource
 	// Watch for changes to secondary resource Pods and requeue the owner Certificate
-	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
+	err = c.Watch(&source.Kind{Type: &certmanagerv1.Certificate{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &certmanagerv1alpha1.Certificate{},
 	})
@@ -126,7 +128,7 @@ func (r *ReconcileCertificate) Reconcile(request reconcile.Request) (reconcile.R
 	}
 	annotations["ibm-cert-manager-operator-generated"] = "true"
 
-	certificate := certmanagerv1.Certificate{
+	certificate := &certmanagerv1.Certificate{
 		TypeMeta: metav1.TypeMeta{Kind: "Certificate", APIVersion: "cert-manager.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            instance.Name,
@@ -137,21 +139,38 @@ func (r *ReconcileCertificate) Reconcile(request reconcile.Request) (reconcile.R
 		},
 		Spec: certmanagerv1.CertificateSpec{
 			CommonName: instance.Spec.CommonName,
-			Duration:   &metav1.Duration{Duration: instance.Spec.Duration.Duration},
+			Duration:   instance.Spec.Duration,
 			IssuerRef: cmmeta.ObjectReference{
 				Name:  instance.Spec.IssuerRef.Name,
 				Kind:  instance.Spec.IssuerRef.Kind,
 				Group: instance.Spec.IssuerRef.Group,
 			},
 			IsCA:        instance.Spec.IsCA,
-			RenewBefore: &metav1.Duration{Duration: instance.Spec.RenewBefore.Duration},
+			RenewBefore: instance.Spec.RenewBefore,
 			SecretName:  instance.Spec.SecretName,
 		},
 	}
-	if err := r.client.Create(context.TODO(), &certificate); err != nil {
+	// Set the certificate v1alpha1 as the controller of the certificate v1
+	if err := controllerutil.SetControllerReference(instance, certificate, r.scheme); err != nil {
+		reqLogger.Error(err, "### DEBUG ### failed to set Owner reference for %s", certificate)
+		return reconcile.Result{}, err
+	}
+
+	if err := r.client.Create(context.TODO(), certificate); err != nil {
 		if errors.IsAlreadyExists(err) {
-			reqLogger.Error(err, "### DEBUG ### v1 Certificate already exists")
+			existingCertificate := &certmanagerv1.Certificate{}
+			if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: certificate.Namespace, Name: certificate.Name}, existingCertificate); err != nil {
+				reqLogger.Error(err, "### DEBUG ### Failed to get v1 Certificate")
+				return reconcile.Result{}, err
+			}
+			certificate.SetResourceVersion(existingCertificate.GetResourceVersion())
+			if err := r.client.Update(context.TODO(), certificate); err != nil {
+				reqLogger.Error(err, "### DEBUG ### Failed to update v1 Certificate")
+				return reconcile.Result{}, err
+			}
+			reqLogger.Info("### DEBUG #### Updated v1 Certificate")
 			return reconcile.Result{}, nil
+
 		}
 		reqLogger.Error(err, "### DEBUG ### Failed to create v1 Certificate")
 		return reconcile.Result{}, err

--- a/pkg/controller/issuer/issuer_controller.go
+++ b/pkg/controller/issuer/issuer_controller.go
@@ -19,19 +19,21 @@ package issuer
 import (
 	"context"
 
-	certmanagerv1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1"
-	certmanagerv1alpha1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	certmanagerv1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1"
+	certmanagerv1alpha1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1alpha1"
 )
 
 var log = logf.Log.WithName("controller_issuer")
@@ -68,7 +70,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// TODO(user): Modify this to be the types you create that are owned by the primary resource
 	// Watch for changes to secondary resource Pods and requeue the owner Issuer
-	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
+	err = c.Watch(&source.Kind{Type: &certmanagerv1.Issuer{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &certmanagerv1alpha1.Issuer{},
 	})
@@ -125,17 +127,16 @@ func (r *ReconcileIssuer) Reconcile(request reconcile.Request) (reconcile.Result
 	}
 	annotations["ibm-cert-manager-operator-generated"] = "true"
 
-	v1Issuer := certmanagerv1.Issuer{
+	v1Issuer := &certmanagerv1.Issuer{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Issuer",
 			APIVersion: "cert-manager.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            instance.Name,
-			Namespace:       instance.Namespace,
-			Labels:          instance.Labels,
-			Annotations:     annotations,
-			OwnerReferences: instance.OwnerReferences,
+			Name:        instance.Name,
+			Namespace:   instance.Namespace,
+			Labels:      instance.Labels,
+			Annotations: annotations,
 		},
 		Spec: certmanagerv1.IssuerSpec{
 			IssuerConfig: certmanagerv1.IssuerConfig{
@@ -144,10 +145,27 @@ func (r *ReconcileIssuer) Reconcile(request reconcile.Request) (reconcile.Result
 		},
 	}
 
-	if err := r.client.Create(context.TODO(), &v1Issuer); err != nil {
+	// Set the issuer v1alpha1 as the controller of the issuer v1
+	if err := controllerutil.SetControllerReference(instance, v1Issuer, r.scheme); err != nil {
+		reqLogger.Error(err, "### DEBUG ### failed to set owner reference for %s", v1Issuer)
+		return reconcile.Result{}, err
+	}
+
+	if err := r.client.Create(context.TODO(), v1Issuer); err != nil {
 		if errors.IsAlreadyExists(err) {
-			reqLogger.Error(err, "### DEBUG ### v1 Issuer already exists")
+			existingIssuer := &certmanagerv1.Issuer{}
+			if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: v1Issuer.Namespace, Name: v1Issuer.Name}, existingIssuer); err != nil {
+				reqLogger.Error(err, "### DEBUG ### Failed to get v1 Issuer")
+				return reconcile.Result{}, err
+			}
+			v1Issuer.SetResourceVersion(existingIssuer.GetResourceVersion())
+			if err := r.client.Update(context.TODO(), v1Issuer); err != nil {
+				reqLogger.Error(err, "### DEBUG ### Failed to update v1 Issuer")
+				return reconcile.Result{}, err
+			}
+			reqLogger.Info("### DEBUG #### Updated v1 Issuer")
 			return reconcile.Result{}, nil
+
 		}
 		reqLogger.Error(err, "### DEBUG ### Failed to create v1 Issuer")
 		return reconcile.Result{}, err


### PR DESCRIPTION
Issue: We can't inherit owner references from v1alpha1 cert-manager objects because we don't have the relevant permission to the parent resources of v1alpha1 cert-manager objects.

Error message:
```
forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on
```


This PR implements:

Set v0.10 cert manager CRs as the owner of v1.x cert manager CRs
Enable update logic: When v0.10 cert manager CRs are updated, v1.x cert manager CRs will be updated as well
Need to consider:

Should we watch the change of v1.x cert manager CRs and trigger the reconciliation for its owner?