### PR TITLE
fixed run-csv configmap error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ tags
 .vscode/*
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
+
+tmp/

--- a/Makefile
+++ b/Makefile
@@ -281,6 +281,17 @@ dev-csv:
 # deploys CSV using currently installed OLM on the cluster
 # change pullPolicy value in pkg/resources/constants.go to always pull operands
 run-csv:
+	mkdir -p tmp
+	cp deploy/olm-catalog/ibm-cert-manager-operator/${VERSION}/acme.cert-manager.io_challenges_crd.yaml tmp
+	cp deploy/olm-catalog/ibm-cert-manager-operator/${VERSION}/acme.cert-manager.io_orders_crd.yaml tmp
+	cp deploy/olm-catalog/ibm-cert-manager-operator/${VERSION}/cert-manager.io_certificaterequests_crd.yaml tmp
+	cp deploy/olm-catalog/ibm-cert-manager-operator/${VERSION}/cert-manager.io_clusterissuers_crd.yaml tmp
+
+	yq eval -i 'del(.spec.versions[0], .spec.versions[0], .spec.versions[0])' deploy/olm-catalog/ibm-cert-manager-operator/${VERSION}/acme.cert-manager.io_challenges_crd.yaml
+	yq eval -i 'del(.spec.versions[0], .spec.versions[0], .spec.versions[0])' deploy/olm-catalog/ibm-cert-manager-operator/${VERSION}/acme.cert-manager.io_orders_crd.yaml
+	yq eval -i 'del(.spec.versions[0], .spec.versions[0], .spec.versions[0])' deploy/olm-catalog/ibm-cert-manager-operator/${VERSION}/cert-manager.io_certificaterequests_crd.yaml
+	yq eval -i 'del(.spec.versions[0], .spec.versions[0], .spec.versions[0])' deploy/olm-catalog/ibm-cert-manager-operator/${VERSION}/cert-manager.io_clusterissuers_crd.yaml
+
 	operator-sdk run packagemanifests \
 		--operator-version ${VERSION} \
 		--operator-namespace ibm-common-services \
@@ -295,5 +306,10 @@ cleanup-csv:
 		--operator-version ${VERSION} \
 		--operator-namespace ibm-common-services \
 		--olm-namespace openshift-operator-lifecycle-manager
+
+	cp tmp/acme.cert-manager.io_challenges_crd.yaml deploy/olm-catalog/ibm-cert-manager-operator/${VERSION}
+	cp tmp/acme.cert-manager.io_orders_crd.yaml deploy/olm-catalog/ibm-cert-manager-operator/${VERSION}
+	cp tmp/cert-manager.io_certificaterequests_crd.yaml deploy/olm-catalog/ibm-cert-manager-operator/${VERSION}
+	cp tmp/cert-manager.io_clusterissuers_crd.yaml deploy/olm-catalog/ibm-cert-manager-operator/${VERSION}
 
 .PHONY: all work build check lint test coverage images multiarch-image

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/ibm-cert-manager-operator.v3.13.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/ibm-cert-manager-operator.v3.13.0.clusterserviceversion.yaml
@@ -654,6 +654,22 @@ spec:
                         value: ibm-cert-manager-operator
                     image: quay.io/horis233/ibm-certmanager-operator
                     imagePullPolicy: Always
+                    livenessProbe:
+                      failureThreshold: 10
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 120
+                      periodSeconds: 60
+                      timeoutSeconds: 10
+                    readinessProbe:
+                      failureThreshold: 10
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 60
+                      periodSeconds: 20
+                      timeoutSeconds: 3
                     name: ibm-cert-manager-operator
                     resources:
                       limits:

--- a/pkg/controller/certificate/certificate_controller.go
+++ b/pkg/controller/certificate/certificate_controller.go
@@ -137,14 +137,14 @@ func (r *ReconcileCertificate) Reconcile(request reconcile.Request) (reconcile.R
 		},
 		Spec: certmanagerv1.CertificateSpec{
 			CommonName: instance.Spec.CommonName,
-			Duration:   &metav1.Duration{Duration: instance.Spec.Duration.Duration},
+			Duration:   instance.Spec.Duration,
 			IssuerRef: cmmeta.ObjectReference{
 				Name:  instance.Spec.IssuerRef.Name,
 				Kind:  instance.Spec.IssuerRef.Kind,
 				Group: instance.Spec.IssuerRef.Group,
 			},
 			IsCA:        instance.Spec.IsCA,
-			RenewBefore: &metav1.Duration{Duration: instance.Spec.RenewBefore.Duration},
+			RenewBefore: instance.Spec.RenewBefore,
 			SecretName:  instance.Spec.SecretName,
 		},
 	}


### PR DESCRIPTION
temporarily remove unnecessary versions from CRDs (v1alpha2, v1beta1, etc.) because operator-sdk generates a configmap too large for Kubernetes

update branch with master changes