### PR TITLE
disable leader election

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
-	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
@@ -110,13 +109,8 @@ func main() {
 	}
 
 	ctx := context.TODO()
-	// Become the leader before proceeding
-	err = leader.Become(ctx, "ibm-cert-manager-operator-lock")
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
 
+	// TODO: Enable leader election in the operator manager
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
 		MapperProvider:         restmapper.NewDynamicRESTMapper,


### PR DESCRIPTION
Leader election from operator-sdk will block probe servers staring up and block the operator upgade