### PR TITLE
add pod refresh controller

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -28,10 +28,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 
-	"github.com/ibm/ibm-cert-manager-operator/pkg/apis"
-	"github.com/ibm/ibm-cert-manager-operator/pkg/controller"
-	"github.com/ibm/ibm-cert-manager-operator/version"
-
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -42,9 +38,9 @@ import (
 	admRegv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	apiRegv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -53,6 +49,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	secretshare "github.com/IBM/ibm-secretshare-operator/api/v1"
+
+	"github.com/ibm/ibm-cert-manager-operator/pkg/apis"
+	"github.com/ibm/ibm-cert-manager-operator/pkg/controller"
+	"github.com/ibm/ibm-cert-manager-operator/version"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -132,16 +132,15 @@ func main() {
 	}
 
 	// Setup Scheme for all resources
+	if err := clientgoscheme.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
 	if err := apiextensionv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}
-
-	if err := rbacv1.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-
 	if err := apiRegv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)

--- a/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/ibm-cert-manager-operator.v3.13.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-cert-manager-operator/3.13.0/ibm-cert-manager-operator.v3.13.0.clusterserviceversion.yaml
@@ -673,8 +673,8 @@ spec:
                     name: ibm-cert-manager-operator
                     resources:
                       limits:
-                        cpu: 100m
-                        memory: 300Mi
+                        cpu: 200m
+                        memory: 500Mi
                       requests:
                         cpu: 10m
                         memory: 50Mi

--- a/pkg/controller/add_podrefresh.go
+++ b/pkg/controller/add_podrefresh.go
@@ -1,0 +1,26 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package controller
+
+import (
+	"github.com/ibm/ibm-cert-manager-operator/pkg/controller/podrefresh"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, podrefresh.Add)
+}

--- a/pkg/controller/certificaterefresh/certificaterefresh_controller.go
+++ b/pkg/controller/certificaterefresh/certificaterefresh_controller.go
@@ -21,15 +21,11 @@ import (
 	"fmt"
 	"time"
 
-	certmgr "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1alpha1"
-	operatorv1alpha1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/operator/v1alpha1"
-	res "github.com/ibm/ibm-cert-manager-operator/pkg/resources"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/fields"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,6 +36,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	certmgr "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1"
+	operatorv1alpha1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/operator/v1alpha1"
+	res "github.com/ibm/ibm-cert-manager-operator/pkg/resources"
 )
 
 var log = logf.Log.WithName("controller_certificaterefresh")
@@ -190,11 +190,13 @@ func (r *ReconcileCertificateRefresh) Reconcile(request reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	// Fetch clusterissuers
-	clusterissuers, err := r.findClusterIssuersBasedOnCA(caSecret)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
+	//nolint
+	//TODO: Add clusterissuer to api
+	// // Fetch clusterissuers
+	// clusterissuers, err := r.findClusterIssuersBasedOnCA(caSecret)
+	// if err != nil {
+	// 	return reconcile.Result{}, err
+	// }
 
 	// // Fetch all the secrets of leaf certificates issued by these issuers/clusterissuers
 	var leafSecrets []*corev1.Secret
@@ -207,22 +209,26 @@ func (r *ReconcileCertificateRefresh) Reconcile(request reconcile.Request) (reco
 		}
 	}
 
-	allNamespaces, err := r.getAllNamespaces()
-	if err != nil {
-		log.Error(err, "Error listing all namespaces - requeue the request")
-		return reconcile.Result{}, err
-	}
+	//nolint
+	//TODO: Add clusterissuer to api
+	// allNamespaces, err := r.getAllNamespaces()
+	// if err != nil {
+	// 	log.Error(err, "Error listing all namespaces - requeue the request")
+	// 	return reconcile.Result{}, err
+	// }
 
-	for _, clusterissuer := range clusterissuers {
-		for _, ns := range allNamespaces.Items {
-			clusterLeafSecrets, err := r.findLeafSecrets(clusterissuer.Name, ns.Name)
-			if err != nil {
-				log.Error(err, "Error reading the leaf certificates for clusterissuer - requeue the request")
-				return reconcile.Result{}, err
-			}
-			leafSecrets = append(leafSecrets, clusterLeafSecrets...)
-		}
-	}
+	//nolint
+	//TODO: Add clusterissuer to api
+	// for _, clusterissuer := range clusterissuers {
+	// 	for _, ns := range allNamespaces.Items {
+	// 		clusterLeafSecrets, err := r.findLeafSecrets(clusterissuer.Name, ns.Name)
+	// 		if err != nil {
+	// 			log.Error(err, "Error reading the leaf certificates for clusterissuer - requeue the request")
+	// 			return reconcile.Result{}, err
+	// 		}
+	// 		leafSecrets = append(leafSecrets, clusterLeafSecrets...)
+	// 	}
+	// }
 
 	// Compare ca.crt in leaf with tls.crt of CA
 	// If the values don't match, delete the secret; if error, requeue else don't requeue
@@ -299,24 +305,24 @@ func (r *ReconcileCertificateRefresh) findIssuersBasedOnCA(caSecret *corev1.Secr
 	return issuers, err
 }
 
-// findClusterIssuersBasedOnCA finds issuers that are based on the given CA secret
-func (r *ReconcileCertificateRefresh) findClusterIssuersBasedOnCA(caSecret *corev1.Secret) ([]certmgr.ClusterIssuer, error) {
+// // findClusterIssuersBasedOnCA finds issuers that are based on the given CA secret
+// func (r *ReconcileCertificateRefresh) findClusterIssuersBasedOnCA(caSecret *corev1.Secret) ([]certmgr.ClusterIssuer, error) {
 
-	var clusterissuers []certmgr.ClusterIssuer
+// 	var clusterissuers []certmgr.ClusterIssuer
 
-	clusterIssuerList := &certmgr.ClusterIssuerList{}
-	err := r.client.List(context.TODO(), clusterIssuerList, &client.ListOptions{})
+// 	clusterIssuerList := &certmgr.ClusterIssuerList{}
+// 	err := r.client.List(context.TODO(), clusterIssuerList, &client.ListOptions{})
 
-	if err == nil {
-		for _, cissuer := range clusterIssuerList.Items {
-			if cissuer.Spec.CA != nil && cissuer.Spec.CA.SecretName == caSecret.Name {
-				clusterissuers = append(clusterissuers, cissuer)
-			}
-		}
-	}
+// 	if err == nil {
+// 		for _, cissuer := range clusterIssuerList.Items {
+// 			if cissuer.Spec.CA != nil && cissuer.Spec.CA.SecretName == caSecret.Name {
+// 				clusterissuers = append(clusterissuers, cissuer)
+// 			}
+// 		}
+// 	}
 
-	return clusterissuers, err
-}
+// 	return clusterissuers, err
+// }
 
 // findLeafSecrets finds issuers that are based on the given CA secret
 func (r *ReconcileCertificateRefresh) findLeafSecrets(issuedBy string, namespace string) ([]*corev1.Secret, error) {

--- a/pkg/controller/podrefresh/podrefresh_controller.go
+++ b/pkg/controller/podrefresh/podrefresh_controller.go
@@ -1,0 +1,335 @@
+//
+// Copyright 2021 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package podrefresh
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	certmanagerv1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1"
+)
+
+var log = logf.Log.WithName("controller_podrefresh")
+var (
+	// TODO support cert-manager.io
+	restartLabel        = "certmanager.k8s.io/time-restarted"
+	noRestartAnnotation = "certmanager.k8s.io/disable-auto-restart"
+	t                   = "true"
+)
+
+/**
+* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
+* business logic.  Delete these comments after modifying this file.*
+ */
+
+// Add creates a new podrefresh Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &Reconcilepodrefresh{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("podrefresh-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to Certificates in the cluster
+	err = c.Watch(&source.Kind{Type: &certmanagerv1.Certificate{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to secrets in the cluster
+	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: &certMapper{mgr.GetClient()},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type certMapper struct {
+	client.Client
+}
+
+func (mapper *certMapper) Map(obj handler.MapObject) []reconcile.Request {
+	var requests []reconcile.Request
+
+	secrets := &corev1.SecretList{}
+
+	err := mapper.List(context.TODO(), secrets, &client.ListOptions{})
+	if err != nil {
+		return requests
+	}
+
+	for _, secret := range secrets.Items {
+		certName, ok := secret.Annotations["cert-manager.io/certificate-name"]
+		if !ok {
+			continue
+		}
+
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: certName, Namespace: secret.Namespace}})
+	}
+
+	return requests
+}
+
+// blank assignment to verify that Reconcilepodrefresh implements reconcile.Reconciler
+var _ reconcile.Reconciler = &Reconcilepodrefresh{}
+
+// Reconcilepodrefresh reconciles a podrefresh object
+type Reconcilepodrefresh struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a Certificate object and makes changes based on the state read
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *Reconcilepodrefresh) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling podrefresh")
+
+	// Get the certificate that invoked reconciliation is a CA in the listOfCAs
+
+	cert := &certmanagerv1.Certificate{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, cert)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile req
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	if len(cert.Status.Conditions) > 0 && cert.Status.NotAfter != nil {
+		if err := r.restart(cert.Spec.SecretName, cert.Name); err != nil {
+			reqLogger.Error(err, "Failed to fresh pod")
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// pod refresh is enabled. It will edit the deployments, statefulsets, and daemonsets
+// that use the secret being updated, which will trigger the pod to be restarted.
+func (r *Reconcilepodrefresh) restart(secret, cert string) error {
+	timeNow := time.Now().Format("2006-1-2.1504")
+	deployments := &appsv1.DeploymentList{}
+	if err := r.client.List(context.TODO(), deployments); err != nil {
+		return fmt.Errorf("error getting deployments: %v", err)
+	}
+	deploymentsToUpdate, err := r.getDeploymentsNeedUpdate(secret)
+	if err != nil {
+		return err
+	}
+
+	if err := r.updateDeploymentAnnotations(deploymentsToUpdate, cert, secret, timeNow); err != nil {
+		return err
+	}
+
+	statefulsetsToUpdate, err := r.getStsNeedUpdate(secret)
+	if err != nil {
+		return err
+	}
+	if err := r.updateStsAnnotations(statefulsetsToUpdate, cert, secret, timeNow); err != nil {
+		return err
+	}
+
+	daemonsetsToUpdate, err := r.getDaemonSetNeedUpdate(secret)
+	if err != nil {
+		return err
+	}
+	if err := r.updateDaemonSetAnnotations(daemonsetsToUpdate, cert, secret, timeNow); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Reconcilepodrefresh) getDeploymentsNeedUpdate(secret string) ([]appsv1.Deployment, error) {
+	deploymentsToUpdate := make([]appsv1.Deployment, 0)
+	deployments := &appsv1.DeploymentList{}
+	if err := r.client.List(context.TODO(), deployments); err != nil {
+		return deploymentsToUpdate, fmt.Errorf("error getting deployments: %v", err)
+	}
+NEXT_DEPLOYMENT:
+	for _, deployment := range deployments.Items {
+		for _, container := range deployment.Spec.Template.Spec.Containers {
+			for _, env := range container.Env {
+				if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil && env.ValueFrom.SecretKeyRef.Name == secret && deployment.ObjectMeta.Annotations[noRestartAnnotation] != t {
+					deploymentsToUpdate = append(deploymentsToUpdate, deployment)
+					continue NEXT_DEPLOYMENT
+				}
+			}
+		}
+		for _, volume := range deployment.Spec.Template.Spec.Volumes {
+			if volume.Secret != nil && volume.Secret.SecretName != "" && volume.Secret.SecretName == secret && deployment.ObjectMeta.Annotations[noRestartAnnotation] != t {
+				deploymentsToUpdate = append(deploymentsToUpdate, deployment)
+				continue NEXT_DEPLOYMENT
+			}
+			if volume.Projected != nil && volume.Projected.Sources != nil && deployment.ObjectMeta.Annotations[noRestartAnnotation] != t {
+				for _, source := range volume.Projected.Sources {
+					if source.Secret != nil && source.Secret.Name == secret {
+						deploymentsToUpdate = append(deploymentsToUpdate, deployment)
+						continue NEXT_DEPLOYMENT
+					}
+				}
+			}
+		}
+	}
+	return deploymentsToUpdate, nil
+}
+
+func (r *Reconcilepodrefresh) getStsNeedUpdate(secret string) ([]appsv1.StatefulSet, error) {
+	statefulsetsToUpdate := make([]appsv1.StatefulSet, 0)
+	statefulsets := &appsv1.StatefulSetList{}
+	err := r.client.List(context.TODO(), statefulsets)
+	if err != nil {
+		return statefulsetsToUpdate, fmt.Errorf("error getting statefulsets: %v", err)
+	}
+NEXT_STATEFULSET:
+	for _, statefulset := range statefulsets.Items {
+		for _, container := range statefulset.Spec.Template.Spec.Containers {
+			for _, env := range container.Env {
+				if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil && env.ValueFrom.SecretKeyRef.Name == secret && statefulset.ObjectMeta.Annotations[noRestartAnnotation] != t {
+					statefulsetsToUpdate = append(statefulsetsToUpdate, statefulset)
+					continue NEXT_STATEFULSET
+				}
+			}
+		}
+		for _, volume := range statefulset.Spec.Template.Spec.Volumes {
+			if volume.Secret != nil && volume.Secret.SecretName != "" && volume.Secret.SecretName == secret && statefulset.ObjectMeta.Annotations[noRestartAnnotation] != t {
+				statefulsetsToUpdate = append(statefulsetsToUpdate, statefulset)
+				continue NEXT_STATEFULSET
+			}
+			if volume.Projected != nil && volume.Projected.Sources != nil && statefulset.ObjectMeta.Annotations[noRestartAnnotation] != t {
+				for _, source := range volume.Projected.Sources {
+					if source.Secret != nil && source.Secret.Name == secret {
+						statefulsetsToUpdate = append(statefulsetsToUpdate, statefulset)
+						continue NEXT_STATEFULSET
+					}
+				}
+			}
+		}
+	}
+	return statefulsetsToUpdate, nil
+}
+
+func (r *Reconcilepodrefresh) getDaemonSetNeedUpdate(secret string) ([]appsv1.DaemonSet, error) {
+	daemonsetsToUpdate := make([]appsv1.DaemonSet, 0)
+	daemonsets := &appsv1.DaemonSetList{}
+	if err := r.client.List(context.TODO(), daemonsets); err != nil {
+		return daemonsetsToUpdate, fmt.Errorf("error getting daemonsets: %v", err)
+	}
+NEXT_DAEMONSET:
+	for _, daemonset := range daemonsets.Items {
+		for _, container := range daemonset.Spec.Template.Spec.Containers {
+			for _, env := range container.Env {
+				if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil && env.ValueFrom.SecretKeyRef.Name == secret && daemonset.ObjectMeta.Annotations[noRestartAnnotation] != t {
+					daemonsetsToUpdate = append(daemonsetsToUpdate, daemonset)
+					continue NEXT_DAEMONSET
+				}
+			}
+		}
+		for _, volume := range daemonset.Spec.Template.Spec.Volumes {
+			if volume.Secret != nil && volume.Secret.SecretName != "" && volume.Secret.SecretName == secret && daemonset.ObjectMeta.Annotations[noRestartAnnotation] != t {
+				daemonsetsToUpdate = append(daemonsetsToUpdate, daemonset)
+				continue NEXT_DAEMONSET
+			}
+			if volume.Projected != nil && volume.Projected.Sources != nil && daemonset.ObjectMeta.Annotations[noRestartAnnotation] != t {
+				for _, source := range volume.Projected.Sources {
+					if source.Secret != nil && source.Secret.Name == secret {
+						daemonsetsToUpdate = append(daemonsetsToUpdate, daemonset)
+						continue NEXT_DAEMONSET
+					}
+				}
+			}
+		}
+	}
+	return daemonsetsToUpdate, nil
+}
+
+func (r *Reconcilepodrefresh) updateDeploymentAnnotations(deploymentsToUpdate []appsv1.Deployment, cert, secret, timeNow string) error {
+	for _, deployment := range deploymentsToUpdate {
+		//in case of deployments not having labels section, create the label section
+		if deployment.ObjectMeta.Labels == nil {
+			deployment.ObjectMeta.Labels = make(map[string]string)
+		}
+		deployment.ObjectMeta.Labels[restartLabel] = timeNow
+		deployment.Spec.Template.ObjectMeta.Labels[restartLabel] = timeNow
+		err := r.client.Update(context.TODO(), &deployment)
+		if err != nil {
+			return fmt.Errorf("error updating deployment: %v", err)
+		}
+		log.Info(timeNow, " Cert-Manager Restarting Resource:", "Certificate=", cert, "Secret=", secret, "Deployment=", deployment.ObjectMeta.Name)
+	}
+	return nil
+}
+
+func (r *Reconcilepodrefresh) updateStsAnnotations(statefulsetsToUpdate []appsv1.StatefulSet, cert, secret, timeNow string) error {
+	for _, statefulset := range statefulsetsToUpdate {
+		statefulset.ObjectMeta.Labels[restartLabel] = timeNow
+		statefulset.Spec.Template.ObjectMeta.Labels[restartLabel] = timeNow
+		if err := r.client.Update(context.TODO(), &statefulset); err != nil {
+			return fmt.Errorf("error updating statefulset: %v", err)
+		}
+		log.Info(timeNow, " Cert-Manager Restarting Resource:", "Certificate=", cert, "Secret=", secret, "StatefulSet=", statefulset.ObjectMeta.Name)
+	}
+	return nil
+}
+
+func (r *Reconcilepodrefresh) updateDaemonSetAnnotations(daemonsetsToUpdate []appsv1.DaemonSet, cert, secret, timeNow string) error {
+	for _, daemonset := range daemonsetsToUpdate {
+		daemonset.ObjectMeta.Labels[restartLabel] = timeNow
+		daemonset.Spec.Template.ObjectMeta.Labels[restartLabel] = timeNow
+		if err := r.client.Update(context.TODO(), &daemonset); err != nil {
+			return fmt.Errorf("error updating daemonset: %v", err)
+		}
+		log.Info(timeNow, " Cert-Manager Restarting Resource:", "Certificate=", cert, "Secret=", secret, "DaemonSet=", daemonset.ObjectMeta.Name)
+	}
+	return nil
+}


### PR DESCRIPTION
1. Add pod refresh logic to the operator
2. Update certificates refresh controller to watch v1 certificate
3. Increase resources limit because watching secret.

**Limitations:**
1. Pods are restarted too many times. **Fix:** We can restart pods only when secrets are updated or only watch certificates spec change.
2. Watching secrets will make operator resources usage according to the number of secrets. **Fix:** Customize cache to avoid caching secrets.
3. Certificates refresh controller doesn't work with cluster issuer. **Fix:** Add cluster issuer type into operator api.