### PR TITLE
fixed RBAC creation issue

### DIFF
--- a/pkg/controller/certmanager/prereqs.go
+++ b/pkg/controller/certmanager/prereqs.go
@@ -70,7 +70,7 @@ func createRole(instance *operatorv1alpha1.CertManager, scheme *runtime.Scheme, 
 	for _, r := range res.RolesToCreate.Items {
 		log.V(0).Info("Creating role " + r.Name)
 		role := &rbacv1.Role{}
-		err := client.Get(context.Background(), types.NamespacedName{Name: r.Name, Namespace: r.Namespace}, role)
+		err := client.Get(context.Background(), types.NamespacedName{Name: r.Name, Namespace: namespace}, role)
 		if err != nil && apiErrors.IsNotFound(err) {
 			r.ResourceVersion = ""
 			r.Namespace = namespace
@@ -175,7 +175,7 @@ func createRoleBinding(instance *operatorv1alpha1.CertManager, scheme *runtime.S
 		log.V(0).Info("Creating role binding " + b.Name)
 		roleBinding := &rbacv1.RoleBinding{}
 
-		err := client.Get(context.Background(), types.NamespacedName{Name: b.Name, Namespace: b.Namespace}, roleBinding)
+		err := client.Get(context.Background(), types.NamespacedName{Name: b.Name, Namespace: namespace}, roleBinding)
 		if err != nil && apiErrors.IsNotFound(err) {
 			b.ResourceVersion = ""
 			b.Namespace = namespace


### PR DESCRIPTION
After removing hard coded namespace in the RBAC resources (roles and rolebindings), the functions to create the resources were not updated. The GET request to check if the resources existed was still trying to reference the hard coded namespace, which no longer existed.