### PR TITLE
disable certificate and issuer reconciliation to support RHACM 2.2

### DIFF
--- a/pkg/controller/certmanager/certmanager_controller.go
+++ b/pkg/controller/certmanager/certmanager_controller.go
@@ -249,7 +249,7 @@ func (r *ReconcileCertManager) Reconcile(request reconcile.Request) (reconcile.R
 	r.updateEvent(instance, "Instance found", corev1.EventTypeNormal, "Initializing")
 
 	//Check RHACM
-	rhacmVersion, rhacmNamespace, rhacmErr := checkRhacm(r.client)
+	rhacmVersion, rhacmNamespace, rhacmErr := CheckRhacm(r.client)
 	if rhacmErr != nil {
 		// will continue since RHACM most likely not installed
 		// logging error in case there is some other issue

--- a/pkg/controller/certmanager/prereqs.go
+++ b/pkg/controller/certmanager/prereqs.go
@@ -327,7 +327,7 @@ func removeRoles(client client.Client) error {
 }
 
 //CheckRhacm checks if RHACM exists and returns RHACM version and namespace
-func checkRhacm(client client.Client) (string, string, error) {
+func CheckRhacm(client client.Client) (string, string, error) {
 
 	multiClusterHubList := &unstructured.UnstructuredList{}
 	multiClusterHubList.SetGroupVersionKind(res.RhacmGVK)


### PR DESCRIPTION
Please let me know whether it is the correct behavior we want to coordinate with RHACM.

In the EUS version, we keep the ability of refreshing certificate for cert-manager-operator. So we should do the same thing in the latest version.

Reconcile certificate and issuer is the new function added in CS 3.12, and it should be disabled when RHACM 2.2 exists, right?