### PR TITLE
convert leaf certificates when CA is updated

### DIFF
--- a/pkg/controller/certificate/certificate_controller.go
+++ b/pkg/controller/certificate/certificate_controller.go
@@ -308,7 +308,7 @@ func (r *ReconcileCertificate) purgeOldV1() error {
 		return err
 	}
 	for _, v := range oldV1List.Items {
-		if v.Annotations[resources.OperatorGeneratedAnno] == "true" && v.Labels[resources.ProperV1Label] != "true" {
+		if v.Annotations[resources.OperatorGeneratedAnno] == t && v.Labels[resources.ProperV1Label] != t {
 			if err := r.client.Delete(context.TODO(), &v); err != nil {
 				return err
 			}

--- a/pkg/controller/certificate/certificate_controller.go
+++ b/pkg/controller/certificate/certificate_controller.go
@@ -117,7 +117,6 @@ func (r *ReconcileCertificate) Reconcile(request reconcile.Request) (reconcile.R
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
-			reqLogger.Info("hello")
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.

--- a/pkg/controller/certificate/certificate_controller.go
+++ b/pkg/controller/certificate/certificate_controller.go
@@ -183,6 +183,7 @@ func (r *ReconcileCertificate) Reconcile(request reconcile.Request) (reconcile.R
 	if err != nil {
 		if errors.IsNotFound(err) {
 			reqLogger.Info("No secret found, continuing")
+			secret = nil
 		} else {
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/certificaterefresh/certificaterefresh_controller.go
+++ b/pkg/controller/certificaterefresh/certificaterefresh_controller.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	certmgr "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1"
+	certmgrv1alpha1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/certmanager/v1alpha1"
 	operatorv1alpha1 "github.com/ibm/ibm-cert-manager-operator/pkg/apis/operator/v1alpha1"
 	res "github.com/ibm/ibm-cert-manager-operator/pkg/resources"
 )
@@ -107,6 +108,27 @@ func (r *ReconcileCertificateRefresh) Reconcile(request reconcile.Request) (reco
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
+	}
+
+	// trigger conversion controller to handle mixing v1 CA Certificates and
+	// v1alpha1 leaf Certificates
+	if cert.Labels[res.OperatorGeneratedAnno] == "" && cert.Labels[res.ProperV1Label] == "" {
+		v1alpha1 := &certmgrv1alpha1.Certificate{}
+		if err := r.client.Get(context.TODO(), request.NamespacedName, v1alpha1); err != nil {
+			if errors.IsNotFound(err) {
+				// Request object not found, could have been deleted after reconcile req
+				// Return and don't requeue
+				reqLogger.Info("Could not find v1alpha1 certificate")
+				return reconcile.Result{}, nil
+			}
+			return reconcile.Result{}, err
+		}
+		reqLogger.Info("Emptying v1alpha1 Cert status")
+		v1alpha1.Status = certmgrv1alpha1.CertificateStatus{}
+		if err := r.client.Update(context.TODO(), v1alpha1); err != nil {
+			reqLogger.Error(err, "failed to empty v1alpha1 status")
+			return reconcile.Result{}, err
+		}
 	}
 
 	// Adding extra logic to check the duration of cs-ca-certificate. If no fields, then add the fields with default values


### PR DESCRIPTION
Two scenarios covered:

1. After upgrade, v1alpha1 Certificates will eventually be converted to v1, but there is no guarantee that CA is converted before leaf certificates.
2. Some services could decide to implement v1 Certificates before others, so it is possible that a v1 CA is created while some services are still creating v1alpha1 leaf certificates.

How scenarios are addressed:
1. Conversion controller will automatically convert v1alpha1 leaf Certificates when a v1alpha1 CA Certificate is converted
   - make it seem like v1alpha1 leaf is expired by deleting the secret
   - update the v1alpha1 leaf so that a request is sent to conversion controller
2. Assuming v1alpha1 of the CA was not deleted by the service, then make it seem as though the v1alpha1 CA needs to be converted
   - empty the v1alpha1 status, which triggers conversion logic and scenario 1 process is followed