### PR TITLE
refresh v1alpha1 leaf certs

### DIFF
--- a/pkg/controller/certificaterefresh/certificaterefresh_controller.go
+++ b/pkg/controller/certificaterefresh/certificaterefresh_controller.go
@@ -287,7 +287,7 @@ func (r *ReconcileCertificateRefresh) Reconcile(request reconcile.Request) (reco
 		secret := &corev1.Secret{}
 		if err := r.client.Get(context.TODO(), types.NamespacedName{
 			Namespace: c.Namespace,
-			Name:      c.Name,
+			Name:      c.Spec.SecretName,
 		}, secret); err != nil {
 			if !errors.IsNotFound(err) {
 				return reconcile.Result{}, err

--- a/pkg/controller/certificaterefresh/certificaterefresh_controller.go
+++ b/pkg/controller/certificaterefresh/certificaterefresh_controller.go
@@ -245,7 +245,7 @@ func (r *ReconcileCertificateRefresh) Reconcile(request reconcile.Request) (reco
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	log.Info("v1alpha1leaves are ", "list", v1alpha1Leaves)
+	log.V(2).Info("List of v1alpha1 leaves for refresh", "v1alpha1 certs", v1alpha1Leaves)
 
 	//nolint
 	//TODO: Add clusterissuer to api


### PR DESCRIPTION
simplified leaf cert refresh logic when using refresh label

fixed existing issue where only the leaf certificates from the last CA issuer the operator found were refreshed

refactored findLeafSecrets function to only find secrets and extracted out certificate listing logic into its own function