### PR TITLE
fixed pod restart incorrectly restarting pods

### DIFF
--- a/pkg/controller/podrefresh/podrefresh_controller.go
+++ b/pkg/controller/podrefresh/podrefresh_controller.go
@@ -39,7 +39,6 @@ import (
 var log = logf.Log.WithName("controller_podrefresh")
 var (
 	// TODO support cert-manager.io
-	expirationLabel     = "cert-manager.io/expiration"
 	restartLabel        = "certmanager.k8s.io/time-restarted"
 	noRestartAnnotation = "certmanager.k8s.io/disable-auto-restart"
 	t                   = "true"
@@ -111,9 +110,11 @@ func (r *Reconcilepodrefresh) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	if len(cert.Status.Conditions) > 0 && cert.Status.NotAfter != nil {
-		if err := r.restart(cert.Spec.SecretName, cert.Name, cert.Status.NotAfter.Format("2006-1-2.1504")); err != nil {
-			reqLogger.Error(err, "Failed to fresh pod")
-			return reconcile.Result{}, err
+		if c := cert.Status.Conditions; c != nil {
+			if err := r.restart(cert.Spec.SecretName, cert.Name, c[0].LastTransitionTime.Format("2006-1-2.1504")); err != nil {
+				reqLogger.Error(err, "Failed to fresh pod")
+				return reconcile.Result{}, err
+			}
 		}
 	}
 
@@ -122,41 +123,41 @@ func (r *Reconcilepodrefresh) Reconcile(request reconcile.Request) (reconcile.Re
 
 // pod refresh is enabled. It will edit the deployments, statefulsets, and daemonsets
 // that use the secret being updated, which will trigger the pod to be restarted.
-func (r *Reconcilepodrefresh) restart(secret, cert string, expiration string) error {
+func (r *Reconcilepodrefresh) restart(secret, cert string, lastUpdated string) error {
 	timeNow := time.Now().Format("2006-1-2.1504")
 	deployments := &appsv1.DeploymentList{}
 	if err := r.client.List(context.TODO(), deployments); err != nil {
 		return fmt.Errorf("error getting deployments: %v", err)
 	}
-	deploymentsToUpdate, err := r.getDeploymentsNeedUpdate(secret, expiration)
+	deploymentsToUpdate, err := r.getDeploymentsNeedUpdate(secret, lastUpdated)
 	if err != nil {
 		return err
 	}
 
-	if err := r.updateDeploymentAnnotations(deploymentsToUpdate, cert, secret, timeNow, expiration); err != nil {
+	if err := r.updateDeploymentAnnotations(deploymentsToUpdate, cert, secret, timeNow); err != nil {
 		return err
 	}
 
-	statefulsetsToUpdate, err := r.getStsNeedUpdate(secret, expiration)
+	statefulsetsToUpdate, err := r.getStsNeedUpdate(secret, lastUpdated)
 	if err != nil {
 		return err
 	}
-	if err := r.updateStsAnnotations(statefulsetsToUpdate, cert, secret, timeNow, expiration); err != nil {
+	if err := r.updateStsAnnotations(statefulsetsToUpdate, cert, secret, timeNow); err != nil {
 		return err
 	}
 
-	daemonsetsToUpdate, err := r.getDaemonSetNeedUpdate(secret, expiration)
+	daemonsetsToUpdate, err := r.getDaemonSetNeedUpdate(secret, lastUpdated)
 	if err != nil {
 		return err
 	}
-	if err := r.updateDaemonSetAnnotations(daemonsetsToUpdate, cert, secret, timeNow, expiration); err != nil {
+	if err := r.updateDaemonSetAnnotations(daemonsetsToUpdate, cert, secret, timeNow); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (r *Reconcilepodrefresh) getDeploymentsNeedUpdate(secret, expiration string) ([]appsv1.Deployment, error) {
+func (r *Reconcilepodrefresh) getDeploymentsNeedUpdate(secret, lastUpdated string) ([]appsv1.Deployment, error) {
 	deploymentsToUpdate := make([]appsv1.Deployment, 0)
 	deployments := &appsv1.DeploymentList{}
 	if err := r.client.List(context.TODO(), deployments); err != nil {
@@ -164,8 +165,16 @@ func (r *Reconcilepodrefresh) getDeploymentsNeedUpdate(secret, expiration string
 	}
 NEXT_DEPLOYMENT:
 	for _, deployment := range deployments.Items {
-		if deployment.ObjectMeta.Labels != nil {
-			if expiration == deployment.ObjectMeta.Labels[expirationLabel] {
+		if deployment.ObjectMeta.Labels != nil && deployment.ObjectMeta.Labels[restartLabel] != "" {
+			lastUpdatedTime, err := time.Parse("2006-1-2.1504", lastUpdated)
+			if err != nil {
+				return deploymentsToUpdate, fmt.Errorf("error parsing NotAfter time: %v", err)
+			}
+			restartedTime, err := time.Parse("2006-1-2.1504", deployment.ObjectMeta.Labels[restartLabel])
+			if err != nil {
+				return deploymentsToUpdate, fmt.Errorf("error parsing time-restarted: %v", err)
+			}
+			if restartedTime.After(lastUpdatedTime) {
 				continue
 			}
 		}
@@ -195,7 +204,7 @@ NEXT_DEPLOYMENT:
 	return deploymentsToUpdate, nil
 }
 
-func (r *Reconcilepodrefresh) getStsNeedUpdate(secret, expiration string) ([]appsv1.StatefulSet, error) {
+func (r *Reconcilepodrefresh) getStsNeedUpdate(secret, lastUpdated string) ([]appsv1.StatefulSet, error) {
 	statefulsetsToUpdate := make([]appsv1.StatefulSet, 0)
 	statefulsets := &appsv1.StatefulSetList{}
 	err := r.client.List(context.TODO(), statefulsets)
@@ -204,8 +213,16 @@ func (r *Reconcilepodrefresh) getStsNeedUpdate(secret, expiration string) ([]app
 	}
 NEXT_STATEFULSET:
 	for _, statefulset := range statefulsets.Items {
-		if statefulset.ObjectMeta.Labels != nil {
-			if expiration == statefulset.ObjectMeta.Labels[expirationLabel] {
+		if statefulset.ObjectMeta.Labels != nil && statefulset.ObjectMeta.Labels[restartLabel] != "" {
+			lastUpdatedTime, err := time.Parse("2006-1-2.1504", lastUpdated)
+			if err != nil {
+				return statefulsetsToUpdate, fmt.Errorf("error parsing NotAfter time: %v", err)
+			}
+			restartedTime, err := time.Parse("2006-1-2.1504", statefulset.ObjectMeta.Labels[restartLabel])
+			if err != nil {
+				return statefulsetsToUpdate, fmt.Errorf("error parsing time-restarted: %v", err)
+			}
+			if restartedTime.After(lastUpdatedTime) {
 				continue
 			}
 		}
@@ -235,7 +252,7 @@ NEXT_STATEFULSET:
 	return statefulsetsToUpdate, nil
 }
 
-func (r *Reconcilepodrefresh) getDaemonSetNeedUpdate(secret, expiration string) ([]appsv1.DaemonSet, error) {
+func (r *Reconcilepodrefresh) getDaemonSetNeedUpdate(secret, lastUpdated string) ([]appsv1.DaemonSet, error) {
 	daemonsetsToUpdate := make([]appsv1.DaemonSet, 0)
 	daemonsets := &appsv1.DaemonSetList{}
 	if err := r.client.List(context.TODO(), daemonsets); err != nil {
@@ -243,8 +260,16 @@ func (r *Reconcilepodrefresh) getDaemonSetNeedUpdate(secret, expiration string) 
 	}
 NEXT_DAEMONSET:
 	for _, daemonset := range daemonsets.Items {
-		if daemonset.ObjectMeta.Labels != nil {
-			if expiration == daemonset.ObjectMeta.Labels[expirationLabel] {
+		if daemonset.ObjectMeta.Labels != nil && daemonset.ObjectMeta.Labels[restartLabel] != "" {
+			lastUpdatedTime, err := time.Parse("2006-1-2.1504", lastUpdated)
+			if err != nil {
+				return daemonsetsToUpdate, fmt.Errorf("error parsing NotAfter time: %v", err)
+			}
+			restartedTime, err := time.Parse("2006-1-2.1504", daemonset.ObjectMeta.Labels[restartLabel])
+			if err != nil {
+				return daemonsetsToUpdate, fmt.Errorf("error parsing time-restarted: %v", err)
+			}
+			if restartedTime.After(lastUpdatedTime) {
 				continue
 			}
 		}
@@ -274,7 +299,7 @@ NEXT_DAEMONSET:
 	return daemonsetsToUpdate, nil
 }
 
-func (r *Reconcilepodrefresh) updateDeploymentAnnotations(deploymentsToUpdate []appsv1.Deployment, cert, secret, timeNow, expiration string) error {
+func (r *Reconcilepodrefresh) updateDeploymentAnnotations(deploymentsToUpdate []appsv1.Deployment, cert, secret, timeNow string) error {
 	for _, deployment := range deploymentsToUpdate {
 		//in case of deployments not having labels section, create the label section
 		if deployment.ObjectMeta.Labels == nil {
@@ -285,8 +310,6 @@ func (r *Reconcilepodrefresh) updateDeploymentAnnotations(deploymentsToUpdate []
 		}
 		deployment.ObjectMeta.Labels[restartLabel] = timeNow
 		deployment.Spec.Template.ObjectMeta.Labels[restartLabel] = timeNow
-		deployment.ObjectMeta.Labels[expirationLabel] = expiration
-		deployment.Spec.Template.ObjectMeta.Labels[expirationLabel] = expiration
 		err := r.client.Update(context.TODO(), &deployment)
 		if err != nil {
 			return fmt.Errorf("error updating deployment: %v", err)
@@ -296,7 +319,7 @@ func (r *Reconcilepodrefresh) updateDeploymentAnnotations(deploymentsToUpdate []
 	return nil
 }
 
-func (r *Reconcilepodrefresh) updateStsAnnotations(statefulsetsToUpdate []appsv1.StatefulSet, cert, secret, timeNow, expiration string) error {
+func (r *Reconcilepodrefresh) updateStsAnnotations(statefulsetsToUpdate []appsv1.StatefulSet, cert, secret, timeNow string) error {
 	for _, statefulset := range statefulsetsToUpdate {
 		if statefulset.ObjectMeta.Labels == nil {
 			statefulset.ObjectMeta.Labels = make(map[string]string)
@@ -306,8 +329,6 @@ func (r *Reconcilepodrefresh) updateStsAnnotations(statefulsetsToUpdate []appsv1
 		}
 		statefulset.ObjectMeta.Labels[restartLabel] = timeNow
 		statefulset.Spec.Template.ObjectMeta.Labels[restartLabel] = timeNow
-		statefulset.ObjectMeta.Labels[expirationLabel] = expiration
-		statefulset.Spec.Template.ObjectMeta.Labels[expirationLabel] = expiration
 		if err := r.client.Update(context.TODO(), &statefulset); err != nil {
 			return fmt.Errorf("error updating statefulset: %v", err)
 		}
@@ -316,7 +337,7 @@ func (r *Reconcilepodrefresh) updateStsAnnotations(statefulsetsToUpdate []appsv1
 	return nil
 }
 
-func (r *Reconcilepodrefresh) updateDaemonSetAnnotations(daemonsetsToUpdate []appsv1.DaemonSet, cert, secret, timeNow, expiration string) error {
+func (r *Reconcilepodrefresh) updateDaemonSetAnnotations(daemonsetsToUpdate []appsv1.DaemonSet, cert, secret, timeNow string) error {
 	for _, daemonset := range daemonsetsToUpdate {
 		if daemonset.ObjectMeta.Labels == nil {
 			daemonset.ObjectMeta.Labels = make(map[string]string)
@@ -326,8 +347,6 @@ func (r *Reconcilepodrefresh) updateDaemonSetAnnotations(daemonsetsToUpdate []ap
 		}
 		daemonset.ObjectMeta.Labels[restartLabel] = timeNow
 		daemonset.Spec.Template.ObjectMeta.Labels[restartLabel] = timeNow
-		daemonset.ObjectMeta.Labels[expirationLabel] = expiration
-		daemonset.Spec.Template.ObjectMeta.Labels[expirationLabel] = expiration
 		if err := r.client.Update(context.TODO(), &daemonset); err != nil {
 			return fmt.Errorf("error updating daemonset: %v", err)
 		}

--- a/pkg/controller/podrefresh/podrefresh_controller.go
+++ b/pkg/controller/podrefresh/podrefresh_controller.go
@@ -349,16 +349,14 @@ func (isExpiredPredicate) Delete(e event.DeleteEvent) bool {
 func (isExpiredPredicate) Update(e event.UpdateEvent) bool {
 	oldCert := (e.ObjectOld).(*certmanagerv1.Certificate)
 	updatedCert := (e.ObjectNew).(*certmanagerv1.Certificate)
-	if oldCert.Status.NotAfter == nil {
-		return false
+	if oldCert.Status.NotAfter == nil && updatedCert.Status.NotAfter != nil {
+		return true
 	}
-	if updatedCert.Status.NotAfter == nil {
-		return false
+	if updatedCert.Status.NotAfter != nil && oldCert.Status.NotAfter != nil &&
+		!oldCert.Status.NotAfter.Time.Equal(updatedCert.Status.NotAfter.Time) {
+		return true
 	}
-	if oldCert.Status.NotAfter.Time == updatedCert.Status.NotAfter.Time {
-		return false
-	}
-	return true
+	return false
 }
 
 func (isExpiredPredicate) Generic(e event.GenericEvent) bool {


### PR DESCRIPTION
added predicate to filter out all events except for updates to Certificates which signify renewal

removed use of expirationLabel and instead rely on lastTransitionTime and restartLabel. The transitionTime represents when Certificate status was last updated, which should only be done by the cert-manager-controller and when it does, it means certificate secret is being updated. So if restartLabel time is after transitionTime, then that means pod was updated after the secret was updated, and this should work for multiple certificate secrets