### PR TITLE
set leader election namespace for cainjector

### DIFF
--- a/controllers/operator/deploys.go
+++ b/controllers/operator/deploys.go
@@ -139,6 +139,11 @@ func setupDeploy(instance *operatorv1alpha1.CertManager, deploy *appsv1.Deployme
 
 	case res.CertManagerCainjectorName:
 		returningDeploy.Spec.Template.Spec.Containers[0].Image = res.GetImageID(imageRegistry, res.CainjectorImageName, res.ControllerImageVersion, instance.Spec.ImagePostFix, res.CaInjectorImageEnvVar)
+		var leaderElect = "--leader-election-namespace=" + ns
+		var args = make([]string, len(res.DefaultArgs))
+		copy(args, res.DefaultArgs)
+		args = append(args, leaderElect)
+		returningDeploy.Spec.Template.Spec.Containers[0].Args = args
 		//add resource limits and requests for cainjector only if present in CR else use default as defined in constants.go
 		if instance.Spec.CertManagerCAInjector.Resources.Limits != nil {
 			returningDeploy.Spec.Template.Spec.Containers[0].Resources.Limits = instance.Spec.CertManagerCAInjector.Resources.Limits

--- a/controllers/resources/containers.go
+++ b/controllers/resources/containers.go
@@ -145,6 +145,7 @@ var cainjectorContainer = corev1.Container{
 	Name:            CertManagerCainjectorName,
 	Image:           cainjectorImage,
 	ImagePullPolicy: pullPolicy,
+	Args:            []string{leaderElectNS},
 	Env: []corev1.EnvVar{
 		{
 			Name: "POD_NAMESPACE",

--- a/controllers/resources/containers.go
+++ b/controllers/resources/containers.go
@@ -145,7 +145,6 @@ var cainjectorContainer = corev1.Container{
 	Name:            CertManagerCainjectorName,
 	Image:           cainjectorImage,
 	ImagePullPolicy: pullPolicy,
-	Args:            []string{leaderElectNS},
 	Env: []corev1.EnvVar{
 		{
 			Name: "POD_NAMESPACE",


### PR DESCRIPTION
jetstack cert-manager changed the default leader election namespace of cainjector to `kube-system`, so we need to adjust it based on where we deploy cainjector, https://github.com/cert-manager/cert-manager/pull/4359/files#diff-8f19c736bead867fae4a4443ea0e7163ed04dad43c9523b0cd7773c759155074R25