### PR TITLE
Add recommend NameSpace and required instance

### DIFF
--- a/bundle/manifests/ibm-cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-cert-manager-operator.clusterserviceversion.yaml
@@ -31,9 +31,33 @@ metadata:
     categories: Security
     certified: "false"
     containerImage: icr.io/cpopen/ibm-cert-manager-operator:latest
-    createdAt: 2022-02-010T21:31:00Z
+    createdAt: "2023-01-25T20:48:01Z"
     description: Operator for managing deployment of cert-manager service.
     olm.skipRange: <4.0.0
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "operator.ibm.com/v1alpha1",
+        "kind": "CertManager",
+        "metadata":{
+          "name": "default",
+          "labels":{
+            "app.kubernetes.io/instance": "ibm-cert-manager-operator",
+            "app.kubernetes.io/managed-by": "ibm-cert-manager-operator",
+            "app.kubernetes.io/name": "cert-manager"
+          }
+        },
+        "spec":{
+          "disableHostNetwork": "true",
+          "enableWebhook": "true",
+          "imageRegistry": "icr.io/cpopen/cpfs",
+          "version": "'4.0.0'",
+          "enableCertRefresh": "true"
+        },
+        "status":{
+          "certManagerStatus": {}
+        }
+      }
+    operatorframework.io/suggested-namespace: ibm-cert-manager
     operators.operatorframework.io/builder: operator-sdk-v1.23.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     support: IBM

--- a/config/manifests/bases/ibm-cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-cert-manager-operator.clusterserviceversion.yaml
@@ -10,6 +10,30 @@ metadata:
     createdAt: 2022-02-010T21:31:00Z
     description: Operator for managing deployment of cert-manager service.
     olm.skipRange: <4.0.0
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "operator.ibm.com/v1alpha1",
+        "kind": "CertManager",
+        "metadata":{
+          "name": "default",
+          "labels":{
+            "app.kubernetes.io/instance": "ibm-cert-manager-operator",
+            "app.kubernetes.io/managed-by": "ibm-cert-manager-operator",
+            "app.kubernetes.io/name": "cert-manager"
+          }
+        },
+        "spec":{
+          "disableHostNetwork": "true",
+          "enableWebhook": "true",
+          "imageRegistry": "icr.io/cpopen/cpfs",
+          "version": "'4.0.0'",
+          "enableCertRefresh": "true"
+        },
+        "status":{
+          "certManagerStatus": {}
+        }
+      }
+    operatorframework.io/suggested-namespace: ibm-cert-manager
     support: IBM
   labels:
     operatorframework.io/arch.amd64: supported


### PR DESCRIPTION
This pr including:
Add `ibm-cert-manager` as recommended namespace
Add `certmanager` instance as a required resource

OLM will not create this `certmanager` instance directly, it will show a required message.
![image](https://user-images.githubusercontent.com/46284272/214690723-4bbd144f-a9e2-4411-be02-325bc43e9698.png)
