### PR TITLE
[LTSR] Make podrestart label more accurate

### DIFF
--- a/controllers/cert-manager/podrefresh_controller.go
+++ b/controllers/cert-manager/podrefresh_controller.go
@@ -82,7 +82,7 @@ func (r *PodRefreshReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	if cert.Status.NotBefore != nil && cert.Status.NotAfter != nil {
-		if err := r.restart(cert.Spec.SecretName, cert.Name, cert.Namespace, cert.Status.NotBefore.Format("2006-1-2.1504")); err != nil {
+		if err := r.restart(cert.Spec.SecretName, cert.Name, cert.Namespace, cert.Status.NotBefore.Format("2006-1-2.150405")); err != nil {
 			reqLogger.Error(err, "Failed to fresh pod")
 			return ctrl.Result{}, err
 		}
@@ -96,7 +96,7 @@ func (r *PodRefreshReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // pod refresh is enabled. It will edit the deployments, statefulsets, and daemonsets
 // that use the secret being updated, which will trigger the pod to be restarted.
 func (r *PodRefreshReconciler) restart(secret, cert, namespace string, lastUpdated string) error {
-	timeNow := time.Now().Format("2006-1-2.1504")
+	timeNow := time.Now().Format("2006-1-2.150405")
 	deployments := &appsv1.DeploymentList{}
 	if err := r.Client.List(context.TODO(), deployments); err != nil {
 		return fmt.Errorf("error getting deployments: %v", err)
@@ -141,11 +141,11 @@ func (r *PodRefreshReconciler) getDeploymentsNeedUpdate(secret, namespace, lastU
 NEXT_DEPLOYMENT:
 	for _, deployment := range deployments.Items {
 		if deployment.ObjectMeta.Labels != nil && deployment.ObjectMeta.Labels[restartLabel] != "" {
-			lastUpdatedTime, err := time.Parse("2006-1-2.1504", lastUpdated)
+			lastUpdatedTime, err := time.Parse("2006-1-2.150405", lastUpdated)
 			if err != nil {
 				return deploymentsToUpdate, fmt.Errorf("error parsing NotAfter time: %v", err)
 			}
-			restartedTime, err := time.Parse("2006-1-2.1504", deployment.ObjectMeta.Labels[restartLabel])
+			restartedTime, err := time.Parse("2006-1-2.150405", deployment.ObjectMeta.Labels[restartLabel])
 			if err != nil {
 				return deploymentsToUpdate, fmt.Errorf("error parsing time-restarted: %v", err)
 			}
@@ -192,11 +192,11 @@ func (r *PodRefreshReconciler) getStsNeedUpdate(secret, namespace, lastUpdated s
 NEXT_STATEFULSET:
 	for _, statefulset := range statefulsets.Items {
 		if statefulset.ObjectMeta.Labels != nil && statefulset.ObjectMeta.Labels[restartLabel] != "" {
-			lastUpdatedTime, err := time.Parse("2006-1-2.1504", lastUpdated)
+			lastUpdatedTime, err := time.Parse("2006-1-2.150405", lastUpdated)
 			if err != nil {
 				return statefulsetsToUpdate, fmt.Errorf("error parsing NotAfter time: %v", err)
 			}
-			restartedTime, err := time.Parse("2006-1-2.1504", statefulset.ObjectMeta.Labels[restartLabel])
+			restartedTime, err := time.Parse("2006-1-2.150405", statefulset.ObjectMeta.Labels[restartLabel])
 			if err != nil {
 				return statefulsetsToUpdate, fmt.Errorf("error parsing time-restarted: %v", err)
 			}
@@ -242,11 +242,11 @@ func (r *PodRefreshReconciler) getDaemonSetNeedUpdate(secret, namespace, lastUpd
 NEXT_DAEMONSET:
 	for _, daemonset := range daemonsets.Items {
 		if daemonset.ObjectMeta.Labels != nil && daemonset.ObjectMeta.Labels[restartLabel] != "" {
-			lastUpdatedTime, err := time.Parse("2006-1-2.1504", lastUpdated)
+			lastUpdatedTime, err := time.Parse("2006-1-2.150405", lastUpdated)
 			if err != nil {
 				return daemonsetsToUpdate, fmt.Errorf("error parsing NotAfter time: %v", err)
 			}
-			restartedTime, err := time.Parse("2006-1-2.1504", daemonset.ObjectMeta.Labels[restartLabel])
+			restartedTime, err := time.Parse("2006-1-2.150405", daemonset.ObjectMeta.Labels[restartLabel])
 			if err != nil {
 				return daemonsetsToUpdate, fmt.Errorf("error parsing time-restarted: %v", err)
 			}


### PR DESCRIPTION
For ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57070
If two certificates are mounted by one pod, and those two certificates are refreshed in the same minute, The second certificate restart will not trigger a pod restart because the time labels are the same.

Test looks good to me:
```
  labels:
    app: auth-idp
    app.kubernetes.io/instance: auth-idp
    certmanager.k8s.io/time-restarted: 2023-6-5.184816
```

But it could cause some pods to restart multiple times in seconds if I delete cs-ca-certificate, not sure if that will cause any other errors
![image](https://github.com/IBM/ibm-cert-manager-operator/assets/46284272/70291964-de8e-46de-b1f0-7662a5470b4d)

This image can be used to verify `quay.io/yuchen_li1/ibm-cert-manager-operator-amd64@sha256:607fd21dbc090ac598315d3d89f5af731780bff322d6576b66261565f375cb91`

How to test:  
1. install common-service
2. install ibm-cert-manager with other services like IAM, CommonUI
3. delete any certificate secret to trigger a pod restart.
4. watch if pod restart correctly