### PR TITLE
fixed label controller not finding cert secrets because of cache filt…

### DIFF
--- a/controllers/cert-manager/v1alpha1_add_label_controller.go
+++ b/controllers/cert-manager/v1alpha1_add_label_controller.go
@@ -34,8 +34,9 @@ import (
 
 // V1Alpha1AddLabelReconciler reconciles a Certificate object
 type V1Alpha1AddLabelReconciler struct {
-	client.Client
-	Scheme *runtime.Scheme
+	Client       client.Client
+	ServerReader client.Reader
+	Scheme       *runtime.Scheme
 }
 
 //+kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch
@@ -107,8 +108,12 @@ func (r *V1Alpha1AddLabelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 func (r *V1Alpha1AddLabelReconciler) getSecret(cert *certmanagerv1alpha1.Certificate) (*corev1.Secret, error) {
 	secretName := cert.Spec.SecretName
 	secret := &corev1.Secret{}
+	// attempt to read from cache first, and if not found, then read directly
+	// from API server because of catch-22
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: cert.Namespace}, secret)
-
+	if errors.IsNotFound(err) {
+		err = r.ServerReader.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: cert.Namespace}, secret)
+	}
 	return secret, err
 }
 

--- a/main.go
+++ b/main.go
@@ -227,15 +227,17 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&certmanagerv1controllers.V1AddLabelReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:       mgr.GetClient(),
+		ServerReader: mgr.GetAPIReader(),
+		Scheme:       mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "V1AddLabel")
 		os.Exit(1)
 	}
 	if err = (&certmanagerv1controllers.V1Alpha1AddLabelReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:       mgr.GetClient(),
+		ServerReader: mgr.GetAPIReader(),
+		Scheme:       mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "V1Alpha1AddLabel")
 		os.Exit(1)


### PR DESCRIPTION
…ering

## How to test

1. See how to test with by running bundle https://github.com/IBM/ibm-cert-manager-operator/blob/release-ltsr/CONTRIBUTING.md#testing-bundle-with-olm
2. After running the bundle, operator pod should be running on the cluster
3. Create the operands by running `oc apply -f config/samples/operator_v1_certmanagerconfig.yaml`
4. Verify that operands are created
5. Create a Certificate and verify that the secret has the label "operator.ibm.com/watched-by-cert-manager"