### PR TITLE
Service labelling

### DIFF
--- a/apis/operator/v1/certmanagerconfig_types.go
+++ b/apis/operator/v1/certmanagerconfig_types.go
@@ -60,6 +60,10 @@ type CertManagerConfigSpec struct {
 	// the CA is refreshed
 	RefreshCertsBasedOnCA []CACertificate `json:"refreshCertsBasedOnCA,omitempty"`
 
+	// Labels describes  foundational services will use this
+	// labels to labels their corresponding resources
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// +optional
 	License LicenseAcceptance `json:"license,omitempty"`
 }

--- a/apis/operator/v1/zz_generated.deepcopy.go
+++ b/apis/operator/v1/zz_generated.deepcopy.go
@@ -121,6 +121,13 @@ func (in *CertManagerConfigSpec) DeepCopyInto(out *CertManagerConfigSpec) {
 		*out = make([]CACertificate, len(*in))
 		copy(*out, *in)
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	out.License = in.License
 }
 

--- a/config/crd/bases/operator.ibm.com_certmanagerconfigs.yaml
+++ b/config/crd/bases/operator.ibm.com_certmanagerconfigs.yaml
@@ -276,6 +276,12 @@ spec:
                 description: ImageRegistry describes the image registry for the operands,
                   e.g. cert-manager-controller
                 type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels describes  foundational services will use this
+                  labels to labels their corresponding resources
+                type: object
               license:
                 description: LicenseAcceptance defines the license specification in
                   CSV

--- a/controllers/operator/certmanager_controller.go
+++ b/controllers/operator/certmanager_controller.go
@@ -371,18 +371,16 @@ func (r *CertManagerReconciler) updateLabels(ctx context.Context) error {
 
 	for key, val := range res.OriginalControllerLabelMap {
 		(res.ControllerLabelMap)[key] = val
-		logd.Info("Controller Label Message:", fmt.Sprint(res.WebhookLabelMap))
 	}
 
 	for key, val := range res.OriginalCainjectorLabelMap {
 		(res.CainjectorLabelMap)[key] = val
-		logd.Info("CA Label Message:", fmt.Sprint(res.WebhookLabelMap))
 	}
 
 	for key, val := range res.OriginalWebhookLabelMap {
 		(res.WebhookLabelMap)[key] = val
-		logd.Info("Webhook Label Message:", fmt.Sprint(res.WebhookLabelMap))
 	}
+	logd.V(2).Info("Webhook LabelMap:", "label:", fmt.Sprint(res.WebhookLabelMap))
 
 	// ADD new label to the Labelmaps
 	// list all the resources in the cluster
@@ -397,7 +395,6 @@ func (r *CertManagerReconciler) updateLabels(ctx context.Context) error {
 			(res.WebhookLabelMap)[key] = val
 			(res.ControllerLabelMap)[key] = val
 			(res.CainjectorLabelMap)[key] = val
-			logd.Info("Webhook Label Message:", fmt.Sprint(res.WebhookLabelMap))
 		}
 	}
 

--- a/controllers/operator/deploys.go
+++ b/controllers/operator/deploys.go
@@ -239,7 +239,7 @@ func deployFinder(client kubernetes.Interface, labels, name string) []appsv1.Dep
 // true otherwise
 func equalDeploys(first, second appsv1.Deployment) bool {
 	statusLog := logd.V(1)
-	if !isSubset(first.ObjectMeta.Labels, second.ObjectMeta.Labels) {
+	if !reflect.DeepEqual(first.ObjectMeta.Labels, second.ObjectMeta.Labels) {
 		statusLog.Info("Labels not equal",
 			"first", fmt.Sprintf("%v", first.ObjectMeta.Labels),
 			"second", fmt.Sprintf("%v", second.ObjectMeta.Labels))
@@ -253,7 +253,7 @@ func equalDeploys(first, second appsv1.Deployment) bool {
 
 	firstPodTemplate := first.Spec.Template
 	secondPodTemplate := second.Spec.Template
-	if !isSubset(firstPodTemplate.ObjectMeta.Labels, secondPodTemplate.ObjectMeta.Labels) {
+	if !reflect.DeepEqual(firstPodTemplate.ObjectMeta.Labels, secondPodTemplate.ObjectMeta.Labels) {
 		statusLog.Info("Pod labels not equal",
 			"first", fmt.Sprintf("%v", firstPodTemplate.ObjectMeta.Labels),
 			"second", fmt.Sprintf("%v", secondPodTemplate.ObjectMeta.Labels))

--- a/controllers/operator/util.go
+++ b/controllers/operator/util.go
@@ -103,3 +103,9 @@ func YamlToObject(yamlContent []byte) (*unstructured.Unstructured, error) {
 
 	return obj, nil
 }
+
+func ClearLabelMap(m map[string]string) {
+	for k := range m {
+		delete(m, k)
+	}
+}

--- a/controllers/resources/constants.go
+++ b/controllers/resources/constants.go
@@ -44,7 +44,7 @@ var timeoutSecondsWebhook int32 = 10
 const certManagerComponentName = "cert-manager"
 
 // ControllerLabelMap is a map of all the labels used by cert-manager-controller
-var ControllerLabelMap = map[string]string{
+var OriginalControllerLabelMap = map[string]string{
 	"app":                          "ibm-cert-manager-controller",
 	"app.kubernetes.io/name":       "ibm-cert-manager-controller",
 	"app.kubernetes.io/component":  certManagerComponentName,
@@ -52,9 +52,10 @@ var ControllerLabelMap = map[string]string{
 	"app.kubernetes.io/instance":   certManagerComponentName,
 	"release":                      certManagerComponentName,
 }
+var ControllerLabelMap = map[string]string{}
 
 // WebhookLabelMap is a map of all the labels used by the cert-manager-webhook
-var WebhookLabelMap = map[string]string{
+var OriginalWebhookLabelMap = map[string]string{
 	"app":                          "ibm-cert-manager-webhook",
 	"app.kubernetes.io/name":       "ibm-cert-manager-webhook",
 	"app.kubernetes.io/component":  certManagerComponentName,
@@ -62,9 +63,10 @@ var WebhookLabelMap = map[string]string{
 	"app.kubernetes.io/instance":   certManagerComponentName,
 	"release":                      certManagerComponentName,
 }
+var WebhookLabelMap = map[string]string{}
 
 // CainjectorLabelMap is a map of all the labels used by the cert-manager-cainjector
-var CainjectorLabelMap = map[string]string{
+var OriginalCainjectorLabelMap = map[string]string{
 	"app":                          "ibm-cert-manager-cainjector",
 	"app.kubernetes.io/name":       "ibm-cert-manager-cainjector",
 	"app.kubernetes.io/component":  certManagerComponentName,
@@ -72,6 +74,7 @@ var CainjectorLabelMap = map[string]string{
 	"app.kubernetes.io/instance":   certManagerComponentName,
 	"release":                      certManagerComponentName,
 }
+var CainjectorLabelMap = map[string]string{}
 
 // PodAnnotations are the annotations required for a pod
 var PodAnnotations = map[string]string{"openshift.io/scc": "restricted", "productName": "IBM Cloud Platform Common Services", "productID": "068a62892a1e4db39641342e592daa25", "productMetric": "FREE"}

--- a/controllers/resources/deployments.go
+++ b/controllers/resources/deployments.go
@@ -32,7 +32,7 @@ var ControllerDeployment = &appsv1.Deployment{
 	Spec: appsv1.DeploymentSpec{
 		Replicas: &replicaCount,
 		Selector: &metav1.LabelSelector{
-			MatchLabels: ControllerLabelMap,
+			MatchLabels: OriginalControllerLabelMap,
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
@@ -49,7 +49,7 @@ var WebhookDeployment = &appsv1.Deployment{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: CertManagerWebhookName,
 		//		Namespace:   DeployNamespace,
-		Labels:      WebhookLabelMap,
+		Labels: WebhookLabelMap,
 	},
 	Spec: appsv1.DeploymentSpec{
 		Replicas: &replicaCount,
@@ -78,7 +78,7 @@ var CainjectorDeployment = &appsv1.Deployment{
 	Spec: appsv1.DeploymentSpec{
 		Replicas: &replicaCount,
 		Selector: &metav1.LabelSelector{
-			MatchLabels: CainjectorLabelMap,
+			MatchLabels: OriginalCainjectorLabelMap,
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
for ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60509
add a new field `.spec.labels` in certmanagerconfig CRD, ibm-cert-manager-operator will use these labels in this field to update its cr, deployments and pods