### PR TITLE
increase testcase cert-rotation time

### DIFF
--- a/test-cert-chain.yaml
+++ b/test-cert-chain.yaml
@@ -42,7 +42,7 @@ spec:
   commonName: test-ca-certificate
   isCA: true
   duration: 720h0m0s
-  renewBefore: 719h58m00s
+  renewBefore: 719h50m00s
 
 ---
 


### PR DESCRIPTION
increase cert-rotation time in testcases to 10 mins, for some slow responsed cluster.