### PR TITLE
update go module to match major release v4

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -15,7 +15,7 @@ resources:
   domain: ibm.com
   group: operator
   kind: CertManagerConfig
-  path: github.com/ibm/ibm-cert-manager-operator/apis/operator/v1
+  path: github.com/ibm/ibm-cert-manager-operator/v4/apis/operator/v1
   version: v1
 - api:
     crdVersion: v1
@@ -24,7 +24,7 @@ resources:
   domain: k8s.io
   group: certmanager
   kind: Issuer
-  path: github.com/ibm/ibm-cert-manager-operator/apis/certmanager/v1alpha1
+  path: github.com/ibm/ibm-cert-manager-operator/v4/apis/certmanager/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -33,7 +33,7 @@ resources:
   domain: k8s.io
   group: certmanager
   kind: Certificate
-  path: github.com/ibm/ibm-cert-manager-operator/apis/certmanager/v1alpha1
+  path: github.com/ibm/ibm-cert-manager-operator/v4/apis/certmanager/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -42,7 +42,7 @@ resources:
   domain: k8s.io
   group: certmanager
   kind: Challenge
-  path: github.com/ibm/ibm-cert-manager-operator/apis/certmanager/v1alpha1
+  path: github.com/ibm/ibm-cert-manager-operator/v4/apis/certmanager/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -51,7 +51,7 @@ resources:
   domain: k8s.io
   group: certmanager
   kind: Order
-  path: github.com/ibm/ibm-cert-manager-operator/apis/certmanager/v1alpha1
+  path: github.com/ibm/ibm-cert-manager-operator/v4/apis/certmanager/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -60,7 +60,7 @@ resources:
   domain: k8s.io
   group: certmanager
   kind: CertificateRequest
-  path: github.com/ibm/ibm-cert-manager-operator/apis/certmanager/v1alpha1
+  path: github.com/ibm/ibm-cert-manager-operator/v4/apis/certmanager/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -69,7 +69,7 @@ resources:
   domain: io
   group: meta.cert-manager
   kind: ""
-  path: github.com/ibm/ibm-cert-manager-operator/apis/meta.cert-manager/v1
+  path: github.com/ibm/ibm-cert-manager-operator/v4/apis/meta.cert-manager/v1
   version: v1
 - api:
     crdVersion: v1
@@ -78,7 +78,7 @@ resources:
   domain: io
   group: acme.cert-manager
   kind: ""
-  path: github.com/ibm/ibm-cert-manager-operator/apis/acme.cert-manager/v1
+  path: github.com/ibm/ibm-cert-manager-operator/v4/apis/acme.cert-manager/v1
   version: v1
 - api:
     crdVersion: v1
@@ -87,7 +87,7 @@ resources:
   domain: io
   group: cert-manager
   kind: Issuer
-  path: github.com/ibm/ibm-cert-manager-operator/apis/cert-manager/v1
+  path: github.com/ibm/ibm-cert-manager-operator/v4/apis/cert-manager/v1
   version: v1
 - api:
     crdVersion: v1
@@ -96,6 +96,6 @@ resources:
   domain: io
   group: cert-manager
   kind: Certificate
-  path: github.com/ibm/ibm-cert-manager-operator/apis/cert-manager/v1
+  path: github.com/ibm/ibm-cert-manager-operator/v4/apis/cert-manager/v1
   version: v1
 version: "3"

--- a/apis/acme.cert-manager/v1/types_issuer.go
+++ b/apis/acme.cert-manager/v1/types_issuer.go
@@ -21,7 +21,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	gwapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	cmmeta "github.com/ibm/ibm-cert-manager-operator/apis/meta.cert-manager/v1"
+	cmmeta "github.com/ibm/ibm-cert-manager-operator/v4/apis/meta.cert-manager/v1"
 )
 
 // ACMEIssuer contains the specification for an ACME issuer.

--- a/apis/acme.cert-manager/v1/zz_generated.deepcopy.go
+++ b/apis/acme.cert-manager/v1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1
 
 import (
-	meta_cert_managerv1 "github.com/ibm/ibm-cert-manager-operator/apis/meta.cert-manager/v1"
+	meta_cert_managerv1 "github.com/ibm/ibm-cert-manager-operator/v4/apis/meta.cert-manager/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"

--- a/apis/cert-manager/v1/certificate_types.go
+++ b/apis/cert-manager/v1/certificate_types.go
@@ -19,7 +19,7 @@ package v1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	cmmeta "github.com/ibm/ibm-cert-manager-operator/apis/meta.cert-manager/v1"
+	cmmeta "github.com/ibm/ibm-cert-manager-operator/v4/apis/meta.cert-manager/v1"
 )
 
 // NOTE: Be mindful of adding OpenAPI validation- see https://github.com/cert-manager/cert-manager/issues/3644

--- a/apis/cert-manager/v1/issuer_types.go
+++ b/apis/cert-manager/v1/issuer_types.go
@@ -19,8 +19,8 @@ package v1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	cmacme "github.com/ibm/ibm-cert-manager-operator/apis/acme.cert-manager/v1"
-	cmmeta "github.com/ibm/ibm-cert-manager-operator/apis/meta.cert-manager/v1"
+	cmacme "github.com/ibm/ibm-cert-manager-operator/v4/apis/acme.cert-manager/v1"
+	cmmeta "github.com/ibm/ibm-cert-manager-operator/v4/apis/meta.cert-manager/v1"
 )
 
 // +genclient

--- a/apis/cert-manager/v1/zz_generated.deepcopy.go
+++ b/apis/cert-manager/v1/zz_generated.deepcopy.go
@@ -21,8 +21,8 @@ limitations under the License.
 package v1
 
 import (
-	acme_cert_managerv1 "github.com/ibm/ibm-cert-manager-operator/apis/acme.cert-manager/v1"
-	meta_cert_managerv1 "github.com/ibm/ibm-cert-manager-operator/apis/meta.cert-manager/v1"
+	acme_cert_managerv1 "github.com/ibm/ibm-cert-manager-operator/v4/apis/acme.cert-manager/v1"
+	meta_cert_managerv1 "github.com/ibm/ibm-cert-manager-operator/v4/apis/meta.cert-manager/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/controllers/operator/certmanager_controller.go
+++ b/controllers/operator/certmanager_controller.go
@@ -22,8 +22,8 @@ import (
 	"reflect"
 	"strings"
 
-	operatorv1 "github.com/ibm/ibm-cert-manager-operator/apis/operator/v1"
-	res "github.com/ibm/ibm-cert-manager-operator/controllers/resources"
+	operatorv1 "github.com/ibm/ibm-cert-manager-operator/v4/apis/operator/v1"
+	res "github.com/ibm/ibm-cert-manager-operator/v4/controllers/resources"
 	admRegv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/controllers/operator/deploys.go
+++ b/controllers/operator/deploys.go
@@ -23,8 +23,8 @@ import (
 	"reflect"
 	"strings"
 
-	operatorv1 "github.com/ibm/ibm-cert-manager-operator/apis/operator/v1"
-	res "github.com/ibm/ibm-cert-manager-operator/controllers/resources"
+	operatorv1 "github.com/ibm/ibm-cert-manager-operator/v4/apis/operator/v1"
+	res "github.com/ibm/ibm-cert-manager-operator/v4/controllers/resources"
 
 	appsv1 "k8s.io/api/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/operator/prereqs-webhook.go
+++ b/controllers/operator/prereqs-webhook.go
@@ -29,8 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	operatorv1 "github.com/ibm/ibm-cert-manager-operator/apis/operator/v1"
-	res "github.com/ibm/ibm-cert-manager-operator/controllers/resources"
+	operatorv1 "github.com/ibm/ibm-cert-manager-operator/v4/apis/operator/v1"
+	res "github.com/ibm/ibm-cert-manager-operator/v4/controllers/resources"
 )
 
 func webhookPrereqs(instance *operatorv1.CertManagerConfig, scheme *runtime.Scheme, client client.Client, reader client.Reader, ns string) error {

--- a/controllers/operator/prereqs.go
+++ b/controllers/operator/prereqs.go
@@ -27,8 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	operatorv1 "github.com/ibm/ibm-cert-manager-operator/apis/operator/v1"
-	res "github.com/ibm/ibm-cert-manager-operator/controllers/resources"
+	operatorv1 "github.com/ibm/ibm-cert-manager-operator/v4/apis/operator/v1"
+	res "github.com/ibm/ibm-cert-manager-operator/v4/controllers/resources"
 )
 
 // Check all RBAC is ready for cert-manager

--- a/controllers/operator/suite_test.go
+++ b/controllers/operator/suite_test.go
@@ -29,7 +29,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	operatorv1 "github.com/ibm/ibm-cert-manager-operator/apis/operator/v1"
+	operatorv1 "github.com/ibm/ibm-cert-manager-operator/v4/apis/operator/v1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ibm/ibm-cert-manager-operator
+module github.com/ibm/ibm-cert-manager-operator/v4
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -38,13 +38,13 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	res "github.com/ibm/ibm-cert-manager-operator/controllers/resources"
+	res "github.com/ibm/ibm-cert-manager-operator/v4/controllers/resources"
 
-	acmecertmanagerv1 "github.com/ibm/ibm-cert-manager-operator/apis/acme.cert-manager/v1"
-	certmanagerv1 "github.com/ibm/ibm-cert-manager-operator/apis/cert-manager/v1"
-	metacertmanagerv1 "github.com/ibm/ibm-cert-manager-operator/apis/meta.cert-manager/v1"
-	operatorv1 "github.com/ibm/ibm-cert-manager-operator/apis/operator/v1"
-	operatorcontrollers "github.com/ibm/ibm-cert-manager-operator/controllers/operator"
+	acmecertmanagerv1 "github.com/ibm/ibm-cert-manager-operator/v4/apis/acme.cert-manager/v1"
+	certmanagerv1 "github.com/ibm/ibm-cert-manager-operator/v4/apis/cert-manager/v1"
+	metacertmanagerv1 "github.com/ibm/ibm-cert-manager-operator/v4/apis/meta.cert-manager/v1"
+	operatorv1 "github.com/ibm/ibm-cert-manager-operator/v4/apis/operator/v1"
+	operatorcontrollers "github.com/ibm/ibm-cert-manager-operator/v4/controllers/operator"
 	//+kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
https://go.dev/ref/mod#major-version-suffixes
Starting with major version 2, module paths must have a major version suffix like /v2 that matches the major version. For example, if a module has the path example.com/mod at v1.0.0, it must have the path example.com/mod/v2 at version v2.0.0.