### PR TITLE
add securityContext .seccompProfile field

### DIFF
--- a/bundle/manifests/ibm-cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-cert-manager-operator.clusterserviceversion.yaml
@@ -564,6 +564,8 @@ spec:
                         ephemeral-storage: 256Mi
                         memory: 50Mi
                     securityContext:
+                      seccompProfile:
+                        type: RuntimeDefault
                       allowPrivilegeEscalation: false
                       capabilities:
                         drop:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -95,6 +95,8 @@ spec:
               memory: 50Mi
               ephemeral-storage: 256Mi
           securityContext:
+            seccompProfile:
+              type: RuntimeDefault
             allowPrivilegeEscalation: false
             capabilities:
               drop:

--- a/controllers/resources/containers.go
+++ b/controllers/resources/containers.go
@@ -33,6 +33,9 @@ var containerSecurityGeneral = &corev1.SecurityContext{
 			"ALL",
 		},
 	},
+	SeccompProfile: &corev1.SeccompProfile{
+		Type: corev1.SeccompProfileTypeRuntimeDefault,
+	},
 }
 
 var containerSecurityWebhook = &corev1.SecurityContext{
@@ -44,6 +47,9 @@ var containerSecurityWebhook = &corev1.SecurityContext{
 		Drop: []corev1.Capability{
 			"ALL",
 		},
+	},
+	SeccompProfile: &corev1.SeccompProfile{
+		Type: corev1.SeccompProfileTypeRuntimeDefault,
 	},
 }
 

--- a/controllers/resources/pods.go
+++ b/controllers/resources/pods.go
@@ -42,8 +42,13 @@ var podAffinity = &corev1.Affinity{
 	},
 }
 
+var seccompProfile = &corev1.SeccompProfile{
+	Type: corev1.SeccompProfileTypeRuntimeDefault,
+}
+
 var podSecurity = &corev1.PodSecurityContext{
-	RunAsNonRoot: &runAsNonRoot,
+	RunAsNonRoot:   &runAsNonRoot,
+	SeccompProfile: seccompProfile,
 }
 
 var certManagerControllerPod = corev1.PodSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
add securityContext .ceccompProfile field to pod container
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64465