### PR TITLE
Adding OLM required metadata

### DIFF
--- a/bundle/manifests/ibm-cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-cert-manager-operator.clusterserviceversion.yaml
@@ -38,6 +38,13 @@ metadata:
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     support: IBM
   labels:
     operatorframework.io/arch.amd64: supported

--- a/config/manifests/bases/ibm-cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-cert-manager-operator.clusterserviceversion.yaml
@@ -12,6 +12,13 @@ metadata:
     olm.skipRange: <4.2.12
     operatorframework.io/suggested-namespace: ibm-cert-manager
     operators.openshift.io/infrastructure-features: '["disconnected"]'
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     support: IBM
   labels:
     operatorframework.io/arch.amd64: supported


### PR DESCRIPTION
Adding OLM required metadataas defined in https://docs.redhat.com/en/documentation/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed and required by RH Certification

What this PR does / why we need it:
OLM has introduced several required annotations which operator bundle is missing.