### PR TITLE
fix: set runAsNonRoot: true in controller deploy

### DIFF
--- a/bundle/manifests/ibm-cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-cert-manager-operator.clusterserviceversion.yaml
@@ -579,6 +579,7 @@ spec:
                       readOnlyRootFilesystem: true
                       seccompProfile:
                         type: RuntimeDefault
+                      runAsNonRoot: true
                 serviceAccountName: ibm-cert-manager-operator
       permissions:
         - rules:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -103,3 +103,4 @@ spec:
               - ALL
             privileged: false
             readOnlyRootFilesystem: true
+            runAsNonRoot: true


### PR DESCRIPTION
To comply with [`restricted` PodSecurityAdmission](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) this PR sets `runAsNonRoot: true` in the controller Deployment security context.