### PR TITLE
Updated operatorNamespace value to certmgrNamespace

### DIFF
--- a/helm-cluster-scoped/templates/cluster-rbac.yaml
+++ b/helm-cluster-scoped/templates/cluster-rbac.yaml
@@ -421,6 +421,6 @@ roleRef:
 subjects:   
   - kind: ServiceAccount
     name: ibm-cert-manager-operator
-    namespace: {{ .Values.global.operatorNamespace }}
+    namespace: {{ .Values.global.certmgrNamespace }}
 
 ---

--- a/helm-cluster-scoped/values.yaml
+++ b/helm-cluster-scoped/values.yaml
@@ -4,4 +4,4 @@ cpfs:
   labels:
 
 global:
-  operatorNamespace: ibm-cert-manager
+  certmgrNamespace: ibm-cert-manager

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ibm-cert-manager-operator
+  namespace: {{ .Values.global.certmgrNamespace }}
   labels:
     app.kubernetes.io/instance: ibm-cert-manager-operator
     app.kubernetes.io/managed-by: ibm-cert-manager-operator

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -14,6 +14,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ibm-cert-manager-operator-leader-election-role
+  namespace: {{ .Values.global.certmgrNamespace }}
   labels:
     app.kubernetes.io/instance: ibm-cert-manager-operator
     app.kubernetes.io/managed-by: ibm-cert-manager-operator
@@ -59,6 +60,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: ibm-cert-manager-operator-leader-election-rolebinding
+  namespace: {{ .Values.global.certmgrNamespace }}
   labels:
     app.kubernetes.io/instance: ibm-cert-manager-operator
     app.kubernetes.io/managed-by: ibm-cert-manager-operator

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata: 
   name: ibm-cert-manager-operator
-  namespace: {{ .Values.global.operatorNamespace }}
+  namespace: {{ .Values.global.certmgrNamespace }}
   labels:
     component-id: {{ .Chart.Name }}
     {{- with .Values.cpfs.labels }}
@@ -74,4 +74,4 @@ roleRef:
 subjects:   
 - kind: ServiceAccount
   name: ibm-cert-manager-operator
-  namespace: {{ .Values.global.operatorNamespace }}
+  namespace: {{ .Values.global.certmgrNamespace }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,5 +5,5 @@ cpfs:
 
 global:
   imagePullPrefix: icr.io
-  operatorNamespace: ibm-cert-manager
+  certmgrNamespace: ibm-cert-manager
   imagePullSecret:


### PR DESCRIPTION
Updated operatorNamespace value to certmgrNamespace between the helm and helm-cluster-scoped folders. Follows consistency with cert-manager having its own namespace and avoiding conflict naming variables between other charts.