### PR TITLE
Bump cert-manager version to 4.2.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ PREV_VERSION ?= 4.2.13
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 4.2.18
+VERSION ?= 4.2.19
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/ibm-cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-cert-manager-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
             "enableCertRefresh": true,
             "enableWebhook": true,
             "imageRegistry": "icr.io/cpopen/cpfs",
-            "version": "4.2.18"
+            "version": "4.2.19"
           },
           "status": {
             "certManagerConfigStatus": ""
@@ -33,7 +33,7 @@ metadata:
     containerImage: icr.io/cpopen/ibm-cert-manager-operator:latest
     createdAt: "2024-10-15T19:26:34Z"
     description: Operator for managing deployment of cert-manager service.
-    olm.skipRange: <4.2.18
+    olm.skipRange: <4.2.19
     operatorframework.io/suggested-namespace: ibm-cert-manager
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
@@ -51,7 +51,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: ibm-cert-manager-operator.v4.2.18
+  name: ibm-cert-manager-operator.v4.2.19
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -540,13 +540,13 @@ spec:
                       - name: OPERATOR_NAME
                         value: ibm-cert-manager-operator
                       - name: ICP_CERT_MANAGER_CONTROLLER_IMAGE
-                        value: icr.io/cpopen/cpfs/icp-cert-manager-controller:4.2.18-jetstack.1.13.3
+                        value: icr.io/cpopen/cpfs/icp-cert-manager-controller:4.2.19-jetstack.1.13.3
                       - name: ICP_CERT_MANAGER_WEBHOOK_IMAGE
-                        value: icr.io/cpopen/cpfs/icp-cert-manager-webhook:4.2.18-jetstack.1.13.3
+                        value: icr.io/cpopen/cpfs/icp-cert-manager-webhook:4.2.19-jetstack.1.13.3
                       - name: ICP_CERT_MANAGER_CAINJECTOR_IMAGE
-                        value: icr.io/cpopen/cpfs/icp-cert-manager-cainjector:4.2.18-jetstack.1.13.3
+                        value: icr.io/cpopen/cpfs/icp-cert-manager-cainjector:4.2.19-jetstack.1.13.3
                       - name: ICP_CERT_MANAGER_ACMESOLVER_IMAGE
-                        value: icr.io/cpopen/cpfs/icp-cert-manager-acmesolver:4.2.18-jetstack.1.13.3
+                        value: icr.io/cpopen/cpfs/icp-cert-manager-acmesolver:4.2.19-jetstack.1.13.3
                     image: icr.io/cpopen/ibm-cert-manager-operator:latest
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
@@ -632,15 +632,15 @@ spec:
   maturity: alpha
   provider:
     name: IBM
-  version: 4.2.18
+  version: 4.2.19
   relatedImages:
     - image: icr.io/cpopen/ibm-cert-manager-operator:latest
       name: IBM_CERT_MANAGER_OPERATOR_IMAGE
-    - image: icr.io/cpopen/cpfs/icp-cert-manager-controller:4.2.18-jetstack.1.13.3
+    - image: icr.io/cpopen/cpfs/icp-cert-manager-controller:4.2.19-jetstack.1.13.3
       name: ICP_CERT_MANAGER_CONTROLLER_IMAGE
-    - image: icr.io/cpopen/cpfs/icp-cert-manager-webhook:4.2.18-jetstack.1.13.3
+    - image: icr.io/cpopen/cpfs/icp-cert-manager-webhook:4.2.19-jetstack.1.13.3
       name: ICP_CERT_MANAGER_WEBHOOK_IMAGE
-    - image: icr.io/cpopen/cpfs/icp-cert-manager-cainjector:4.2.18-jetstack.1.13.3
+    - image: icr.io/cpopen/cpfs/icp-cert-manager-cainjector:4.2.19-jetstack.1.13.3
       name: ICP_CERT_MANAGER_CAINJECTOR_IMAGE
-    - image: icr.io/cpopen/cpfs/icp-cert-manager-acmesolver:4.2.18-jetstack.1.13.3
+    - image: icr.io/cpopen/cpfs/icp-cert-manager-acmesolver:4.2.19-jetstack.1.13.3
       name: ICP_CERT_MANAGER_ACMESOLVER_IMAGE

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -79,13 +79,13 @@ spec:
             - name: OPERATOR_NAME
               value: "ibm-cert-manager-operator"
             - name: ICP_CERT_MANAGER_CONTROLLER_IMAGE
-              value: icr.io/cpopen/cpfs/icp-cert-manager-controller:4.2.18-jetstack.1.13.3
+              value: icr.io/cpopen/cpfs/icp-cert-manager-controller:4.2.19-jetstack.1.13.3
             - name: ICP_CERT_MANAGER_WEBHOOK_IMAGE
-              value: icr.io/cpopen/cpfs/icp-cert-manager-webhook:4.2.18-jetstack.1.13.3
+              value: icr.io/cpopen/cpfs/icp-cert-manager-webhook:4.2.19-jetstack.1.13.3
             - name: ICP_CERT_MANAGER_CAINJECTOR_IMAGE
-              value: icr.io/cpopen/cpfs/icp-cert-manager-cainjector:4.2.18-jetstack.1.13.3
+              value: icr.io/cpopen/cpfs/icp-cert-manager-cainjector:4.2.19-jetstack.1.13.3
             - name: ICP_CERT_MANAGER_ACMESOLVER_IMAGE
-              value: icr.io/cpopen/cpfs/icp-cert-manager-acmesolver:4.2.18-jetstack.1.13.3
+              value: icr.io/cpopen/cpfs/icp-cert-manager-acmesolver:4.2.19-jetstack.1.13.3
           resources:
             limits:
               cpu: 100m

--- a/config/manifests/bases/ibm-cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-cert-manager-operator.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     containerImage: icr.io/cpopen/ibm-cert-manager-operator:latest
     createdAt: 2022-02-010T21:31:00Z
     description: Operator for managing deployment of cert-manager service.
-    olm.skipRange: <4.2.18
+    olm.skipRange: <4.2.19
     operatorframework.io/suggested-namespace: ibm-cert-manager
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     features.operators.openshift.io/disconnected: "true"
@@ -127,12 +127,12 @@ spec:
   relatedImages:
   - image: icr.io/cpopen/ibm-cert-manager-operator:latest
     name: IBM_CERT_MANAGER_OPERATOR_IMAGE
-  - image: icr.io/cpopen/cpfs/icp-cert-manager-controller:4.2.18-jetstack.1.13.3
+  - image: icr.io/cpopen/cpfs/icp-cert-manager-controller:4.2.19-jetstack.1.13.3
     name: ICP_CERT_MANAGER_CONTROLLER_IMAGE
-  - image: icr.io/cpopen/cpfs/icp-cert-manager-webhook:4.2.18-jetstack.1.13.3
+  - image: icr.io/cpopen/cpfs/icp-cert-manager-webhook:4.2.19-jetstack.1.13.3
     name: ICP_CERT_MANAGER_WEBHOOK_IMAGE
-  - image: icr.io/cpopen/cpfs/icp-cert-manager-cainjector:4.2.18-jetstack.1.13.3
+  - image: icr.io/cpopen/cpfs/icp-cert-manager-cainjector:4.2.19-jetstack.1.13.3
     name: ICP_CERT_MANAGER_CAINJECTOR_IMAGE
-  - image: icr.io/cpopen/cpfs/icp-cert-manager-acmesolver:4.2.18-jetstack.1.13.3
+  - image: icr.io/cpopen/cpfs/icp-cert-manager-acmesolver:4.2.19-jetstack.1.13.3
     name: ICP_CERT_MANAGER_ACMESOLVER_IMAGE
   version: 0.0.0

--- a/config/samples/operator_v1_certmanagerconfig.yaml
+++ b/config/samples/operator_v1_certmanagerconfig.yaml
@@ -10,7 +10,7 @@ spec:
   disableHostNetwork: true
   enableWebhook: true
   imageRegistry: icr.io/cpopen/cpfs
-  version: "4.2.18"
+  version: "4.2.19"
   enableCertRefresh: true
 status:
   certManagerConfigStatus: ''

--- a/controllers/resources/certmanager.go
+++ b/controllers/resources/certmanager.go
@@ -60,7 +60,7 @@ spec:
   imageRegistry: icr.io/cpopen/cpfs
   license:
     accept: false
-  version: 4.2.18
+  version: 4.2.19
 status:
   certManagerConfigStatus: ''
 `

--- a/helm-cluster-scoped/Chart.yaml
+++ b/helm-cluster-scoped/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ibm-cert-manager-operator-cluster-scoped
 description: A Helm chart for ibm-cert-manager-operator
 type: application
-version: 4.2.18
-appVersion: 4.2.18
+version: 4.2.19
+appVersion: 4.2.19

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ibm-cert-manager-operator
 description: A Helm chart for ibm-cert-manager-operator
 type: application
-version: 4.2.18
-appVersion: 4.2.18
+version: 4.2.19
+appVersion: 4.2.19

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       hostPID: false
       containers:
         - name: manager
-          image: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperator}}/ibm-cert-manager-operator:4.2.18
+          image: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperator}}/ibm-cert-manager-operator:4.2.19
           command:
           - ibm-cert-manager-operator
           imagePullPolicy: IfNotPresent
@@ -78,13 +78,13 @@ spec:
             - name: OPERATOR_NAME
               value: "ibm-cert-manager-operator"
             - name: ICP_CERT_MANAGER_CONTROLLER_IMAGE
-              value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand}}/icp-cert-manager-controller:4.2.18-jetstack.1.13.3
+              value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand}}/icp-cert-manager-controller:4.2.19-jetstack.1.13.3
             - name: ICP_CERT_MANAGER_WEBHOOK_IMAGE
-              value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand}}/icp-cert-manager-webhook:4.2.18-jetstack.1.13.3
+              value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand}}/icp-cert-manager-webhook:4.2.19-jetstack.1.13.3
             - name: ICP_CERT_MANAGER_CAINJECTOR_IMAGE
-              value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand}}/icp-cert-manager-cainjector:4.2.18-jetstack.1.13.3
+              value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand}}/icp-cert-manager-cainjector:4.2.19-jetstack.1.13.3
             - name: ICP_CERT_MANAGER_ACMESOLVER_IMAGE
-              value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand}}/icp-cert-manager-acmesolver:4.2.18-jetstack.1.13.3
+              value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand}}/icp-cert-manager-acmesolver:4.2.19-jetstack.1.13.3
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
**What this PR does / why we need it:**
Update CM to 4.2.19 for CS 4.6.19