### PR TITLE
Update Cert-Manager migration job version to 0.0.4222

### DIFF
--- a/cert-manager-migration/Chart.yaml
+++ b/cert-manager-migration/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cert-mgr-migration
 description: A Helm chart for migrating IBM Cert Manager Operator from OLM to No OLM
 type: application
-version: 0.0.0
-appVersion: "0.0.0"
+version: 0.0.4222
+appVersion: "0.0.4222"


### PR DESCRIPTION
**What this PR does / why we need it**:
This implies that the migration chart needs to be refreshed with new image for every release, and the image digest will be injected into job template while CICD is building the chart. Subsequently, migration chart version need to be bumped every release like `0.0.x`

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69228